### PR TITLE
fix: restore report and add compact step in upgrade version skill

### DIFF
--- a/.claude/skills/upgrade-versions/SKILL.md
+++ b/.claude/skills/upgrade-versions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: upgrade-versions
 description: Upgrade component versions in the project by checking GitHub releases and updating README and Helm manifests. Use when asked to bump, upgrade, update, or check versions of project components.
-allowed-tools: Read, Bash, Glob, Grep
+allowed-tools: Read, Bash, Glob, Grep, Skill
 ---
 
 # Upgrade Component Versions
@@ -55,7 +55,18 @@ For each helm or crossplane update, update the matching version link in README.m
 component appears in the tech-stack table (both link text and URL contain the version string,
 so a single `sed -i 's|OLD|NEW|g' README.md` handles both).
 
-### 4. Create a PR if any files changed
+### 4. Compact the context
+
+All file edits are now done. The conversation history contains verbose grep/sed output that
+is no longer needed. Compact it before the git steps to reduce context size for remaining turns:
+
+```
+/compact
+```
+
+The compact summary should note which components were updated and to what versions.
+
+### 5. Create a PR if any files changed
 
 ```bash
 DATE=$(date -u +%Y-%m-%d)

--- a/.github/workflows/upgrade-versions.yml
+++ b/.github/workflows/upgrade-versions.yml
@@ -53,6 +53,7 @@ jobs:
               }
             }
           prompt: "/upgrade-versions"
+          display_report: "true"
 
       - name: Mask sensitive values
         if: always()


### PR DESCRIPTION
# Compact Step

  What this should do: by the time all the sed commands finish, the context contains the version report, grep verification outputs, sed confirmations, and thinking blocks — roughly 10K tokens of accumulated tool output that's no
  longer useful. /compact replaces all of that with a short summary (~200–300 tokens), then continues with a clean context for the 5–6 git/PR turns.

  Expected effect: cache_read tokens in the git/PR turns should drop from ~25–28K to ~8–10K (system prompt + compact summary + current turn). Across ~6 turns that's ~100K fewer cache-read tokens, saving roughly $0.05. Not
  dramatic, but it also reduces the risk of hitting context limits as more components get added over time.

  The interesting thing to watch in the next run's JSON is whether context_management stops being null and shows the compaction event.