### PR TITLE
fix: correct REPO_ROOT path in scan-versions.sh

### DIFF
--- a/scripts/scan-versions.sh
+++ b/scripts/scan-versions.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 warn()     { echo "WARN: $*" >&2; }
 make_helm(){ # file component current_version helm_repo_url chart_name


### PR DESCRIPTION
## Summary

- `scan-versions.sh` computed `REPO_ROOT` by going **two levels up** (`/../..`) from `scripts/`, but `scripts/` is only one level deep inside the repo root.
- This caused `REPO_ROOT` to resolve to the **parent** of the repository (e.g., `/home/runner/work/playground` instead of `/home/runner/work/playground/playground` in GitHub Actions).
- All three discovery loops used `$REPO_ROOT/kubernetes` and `$REPO_ROOT/README.md`, which don't exist at that path — so `grep -rl` returned nothing, `items=()` stayed empty, and the script output `[]`.
- `fetch-latest-versions.sh` received an empty array, made zero API calls, and the workflow reported **"0 component(s) need updating"** — silently skipping all 29 components.

**Fix:** change `/../..` → `/..` on line 19 so `REPO_ROOT` correctly resolves to the repository root.

## Test plan

- [ ] Manually trigger the `Upgrade Component Versions` workflow and verify the version report lists components
- [ ] Confirm `scan-versions.sh | fetch-latest-versions.sh` produces a populated table locally from the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)