### PR TITLE
Revert "Fix: upgrade versions path robustness"

### DIFF
--- a/.github/workflows/upgrade-versions.yml
+++ b/.github/workflows/upgrade-versions.yml
@@ -35,8 +35,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Export REPO_ROOT so both scripts use the same repo root path
-          export REPO_ROOT="$(pwd)"
           bash scripts/scan-versions.sh \
             | bash scripts/fetch-latest-versions.sh \
             > .version-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 .setup-env
 
 .env.*

--- a/scripts/fetch-latest-versions.sh
+++ b/scripts/fetch-latest-versions.sh
@@ -9,9 +9,6 @@
 
 set -euo pipefail
 
-# Ensure REPO_ROOT is set correctly for consistent output paths
-REPO_ROOT="${REPO_ROOT:-.}"
-
 input=$(cat)
 date_str=$(date -u +%Y-%m-%d)
 
@@ -116,5 +113,5 @@ total=$(echo "$enriched" | jq '[.[] | select(.needs_update)] | length')
 echo ""
 echo "${total} component(s) need updating."
 
-# Also write the enriched JSON for potential downstream use (to repo root)
-echo "$enriched" > "${REPO_ROOT}/.version-report.json"
+# Also write the enriched JSON for potential downstream use
+echo "$enriched" > .version-report.json


### PR DESCRIPTION
Reverts olga-mir/playground#84

weird error after merge, reverting to test if this is due to this change or something else

```
error: Claude Code returned an error result: Reached maximum number of turns (25)
      at readMessages (/home/runner/work/_actions/anthropics/claude-code-action/fefa07e9c665b7320f08c3b525980457f22f58aa/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:59:17620)

Internal error: directory mismatch for directory "/home/runner/work/_actions/anthropics/claude-code-action/fefa07e9c665b7320f08c3b525980457f22f58aa/tsconfig.json", fd 4. You don't need to do anything, but this indicates a bug.
Error: Action failed with error: SDK execution error: Error: Claude Code returned an error result: Reached maximum number of turns (25)
Error: Process completed with exit code 1.
Run BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
Internal error: directory mismatch for directory "/home/runner/work/_actions/anthropics/claude-code-action/fefa07e9c665b7320f08c3b525980457f22f58aa/tsconfig.json", fd 4. You don't need to do anything, but this indicates a bug.
No buffered inline comments
```

on two runs, last one: https://github.com/olga-mir/playground/actions/runs/25577650738/job/75088659979