### PR TITLE
feat: e2e tests

### DIFF
--- a/.claude/skills/e2e-tests
+++ b/.claude/skills/e2e-tests
@@ -1,0 +1,95 @@
+---
+name: e2e-tests
+description: Run, diagnose, and evolve the e2e test suite for the playground fleet
+triggers:
+  - run e2e
+  - e2e tests
+  - test the cluster
+  - add e2e test
+---
+
+# E2E Test Skill
+
+You help run, interpret, fix, and extend the e2e test suite at `tests/e2e/`.
+
+## Test suite layout
+
+| File | What it tests |
+|---|---|
+| `test_fleet.py` | Node readiness, namespace architecture constraints |
+| `test_flux.py` | All Flux resource conditions on kind/control-plane/apps-dev |
+| `test_crossplane.py` | Provider health, GKECluster XR readiness, workload isolation |
+| `test_kagent.py` | HelmRelease, pods, ModelConfig, ToolServer, REST API |
+| `test_litmus.py` | pod-delete ChaosExperiment lifecycle, verdict=Pass |
+| `test_tenants.py` | Deployment readiness, namespace labels, kgateway |
+
+Shared helpers in `conftest.py`: `wait_for_condition()`, `port_forward()`, `all_flux_resources_ready()`.
+
+## Running tests
+
+```bash
+task e2e:all                          # full suite, skips offline clusters
+task e2e:fast                         # skip slow chaos experiments
+task e2e:cluster CLUSTER=apps_dev     # one cluster
+task e2e:kagent                       # kagent tests only
+task e2e:litmus                       # chaos experiment
+task e2e:file FILE=test_crossplane.py # one file
+```
+
+## How to diagnose a failure
+
+When a test fails, follow this process:
+
+1. **Read the pytest failure message** — it includes the resource name, namespace, and the last condition message from the k8s object.
+
+2. **For Flux failures** (`test_flux.py`):
+   ```bash
+   kubectl --context <ctx> describe <resource-type> <name> -n <namespace>
+   kubectl --context <ctx> logs -n flux-system -l app=source-controller --tail=50
+   ```
+
+3. **For Crossplane failures** (`test_crossplane.py`):
+   ```bash
+   kubectl --context <ctx> describe provider <name>
+   kubectl --context <ctx> get events -n crossplane-system --sort-by='.lastTimestamp'
+   ```
+
+4. **For kagent failures** (`test_kagent.py`):
+   - HelmRelease: `kubectl --context <ctx> describe helmrelease kagent -n kagent-system`
+   - API test: manually run `kubectl --context <ctx> port-forward svc/kagent 8083:8083 -n kagent-system` and `curl http://localhost:8083/api/v1/agents`
+   - If port 8083 gives no response, check the service port: `kubectl --context <ctx> get svc kagent -n kagent-system`
+
+5. **For Litmus failures** (`test_litmus.py`):
+   ```bash
+   kubectl --context <ctx> describe chaosengine e2e-pod-delete -n litmus
+   kubectl --context <ctx> describe chaosresult e2e-pod-delete-pod-delete -n litmus
+   kubectl --context <ctx> logs -n litmus -l name=pod-delete --tail=100
+   ```
+
+## When to fix the test vs. fix the cluster
+
+- **Fix the test** if: the k8s resource exists and works but the test is asserting the wrong thing (wrong port, wrong label selector, wrong resource name after an upgrade).
+- **Fix the cluster** if: the resource is genuinely unhealthy (provider not Healthy, pod CrashLoopBackOff, HelmRelease failing to reconcile).
+
+## Adding tests for a new component
+
+When a new component is added to `kubernetes/namespaces/`:
+
+1. Identify which cluster overlay includes it (kind/control-plane/apps-dev).
+2. Determine the minimum assertions:
+   - HelmRelease Ready (if Flux-managed)
+   - Pods Running (if stateful/unique)
+   - Functional probe: API endpoint, CRD object exists, webhook responds
+3. Add a new test file `test_<component>.py` following the existing pattern:
+   - Import `wait_for_condition`, `port_forward`, `custom_objects` from `conftest`
+   - Use `@pytest.mark.apps_dev` (or `kind`/`control_plane`) + `@pytest.mark.<component>`
+   - Register the new marker in `pytest.ini`
+   - Keep the functional probe deterministic: assert on schema/status, not content
+
+## Determinism rules (enforced in all tests)
+
+- **Never** assert on LLM response text — only on HTTP status codes and JSON schema.
+- **Never** use `time.sleep()` as the primary wait mechanism — always `wait_for_condition()` or poll-until-condition loops with a deadline.
+- **Always** assert on k8s condition `.status == "True"` — not on resource age or counts that change.
+- **Chaos tests**: assert `chaosresult.verdict == "Pass"` — the chaos operator decides this based on whether the target app survived, making it deterministic.
+- **Cleanup**: chaos engines are always deleted in a `finally` block regardless of test outcome.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -16,3 +16,6 @@ includes:
   port-forward:
     taskfile: ./tasks/port-forward.yaml
     dir: .
+  e2e:
+    taskfile: ./tasks/e2e.yaml
+    dir: .

--- a/bootstrap/bootstrap-control-plane-cluster.sh
+++ b/bootstrap/bootstrap-control-plane-cluster.sh
@@ -68,11 +68,12 @@ kubectl --context "${KIND_CLUSTER_CONTEXT}" create secret generic flux-system \
     --dry-run=client -o yaml | kubectl --context "${KIND_CLUSTER_CONTEXT}" apply -f -
 
 echo "Installing Flux Operator via Helm..."
-helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
+# timeout(1) covers the OCI chart download phase; helm's --timeout only covers the k8s --wait phase.
+timeout 360 helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
     --namespace flux-system \
     --kube-context "${KIND_CLUSTER_CONTEXT}" \
     --wait \
-    --timeout=5m
+    --timeout=4m30s
 
 echo "Applying FluxInstance manifest..."
 kubectl --context "${KIND_CLUSTER_CONTEXT}" apply -f "${REPO_ROOT}/kubernetes/clusters/kind/flux-system/flux-instance.yaml"

--- a/tasks/e2e.yaml
+++ b/tasks/e2e.yaml
@@ -1,0 +1,60 @@
+version: "3"
+
+vars:
+  E2E_DIR: tests/e2e
+  VENV: tests/e2e/.venv
+
+tasks:
+  setup:
+    desc: "Create virtualenv and install e2e test dependencies"
+    cmds:
+      - python3 -m venv {{.VENV}}
+      - "{{.VENV}}/bin/pip install -q -r {{.E2E_DIR}}/requirements.txt"
+    status:
+      - test -f {{.VENV}}/bin/pytest
+
+  all:
+    desc: "Run full e2e suite against all available clusters (skips unavailable clusters)"
+    deps: [setup]
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short"
+
+  cluster:
+    desc: "Run e2e tests for one cluster (CLUSTER=kind|control_plane|apps_dev)"
+    deps: [setup]
+    vars:
+      CLUSTER: '{{default "apps_dev" .CLUSTER}}'
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m {{.CLUSTER}}"
+
+  flux:
+    desc: "Run Flux health checks only (all clusters)"
+    deps: [setup]
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m flux"
+
+  kagent:
+    desc: "Run kagent functional tests"
+    deps: [setup]
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/test_kagent.py -v --tb=short"
+
+  litmus:
+    desc: "Run LitmusChaos experiment tests (slow — runs a real chaos experiment)"
+    deps: [setup]
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/test_litmus.py -v --tb=short"
+
+  fast:
+    desc: "Run all tests except slow chaos experiments"
+    deps: [setup]
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m 'not slow'"
+
+  file:
+    desc: "Run a specific test file (FILE=test_flux.py)"
+    deps: [setup]
+    vars:
+      FILE: '{{default "test_fleet.py" .FILE}}'
+    cmds:
+      - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/{{.FILE}} -v --tb=long"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,239 @@
+"""
+Shared fixtures and helpers for e2e tests.
+
+Determinism contract:
+  - All resource assertions use wait_for_condition() — polling until a k8s
+    condition becomes True, never asserting on timing or LLM output content.
+  - Tests skip (not fail) when a cluster context is absent, so a partial fleet
+    doesn't break unrelated suites.
+"""
+
+import logging
+import subprocess
+import time
+import contextlib
+import socket
+
+import pytest
+from kubernetes import client, config as k8s_config
+
+logger = logging.getLogger(__name__)
+
+# ── context discovery ─────────────────────────────────────────────────────────
+
+def _all_contexts() -> list[str]:
+    result = subprocess.run(
+        ["kubectl", "config", "get-contexts", "-o", "name"],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip().splitlines() if result.returncode == 0 else []
+
+
+def _find_context(suffix: str) -> str | None:
+    """Return the first kubeconfig context ending with _{suffix}."""
+    for ctx in _all_contexts():
+        if ctx.endswith(f"_{suffix}"):
+            return ctx
+    return None
+
+
+def _context_reachable(ctx: str) -> bool:
+    """Return True if the API server responds within a short timeout."""
+    result = subprocess.run(
+        ["kubectl", "--context", ctx, "cluster-info", "--request-timeout=5s"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+# ── session-scoped context fixtures ──────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def ctx_kind() -> str:
+    ctx = "kind-kind-test-cluster"
+    if ctx not in _all_contexts() or not _context_reachable(ctx):
+        pytest.skip(f"kind cluster not available ({ctx})")
+    return ctx
+
+
+@pytest.fixture(scope="session")
+def ctx_control_plane() -> str:
+    ctx = _find_context("control-plane")
+    if not ctx or not _context_reachable(ctx):
+        pytest.skip("control-plane cluster not available")
+    return ctx
+
+
+@pytest.fixture(scope="session")
+def ctx_apps_dev() -> str:
+    ctx = _find_context("apps-dev")
+    if not ctx or not _context_reachable(ctx):
+        pytest.skip("apps-dev cluster not available")
+    return ctx
+
+
+# ── k8s client helpers ────────────────────────────────────────────────────────
+
+def k8s_api(ctx: str) -> client.ApiClient:
+    return k8s_config.new_client_from_config(context=ctx)
+
+
+def core_v1(ctx: str) -> client.CoreV1Api:
+    return client.CoreV1Api(api_client=k8s_api(ctx))
+
+
+def custom_objects(ctx: str) -> client.CustomObjectsApi:
+    return client.CustomObjectsApi(api_client=k8s_api(ctx))
+
+
+def apps_v1(ctx: str) -> client.AppsV1Api:
+    return client.AppsV1Api(api_client=k8s_api(ctx))
+
+
+# ── condition polling ─────────────────────────────────────────────────────────
+
+def wait_for_condition(
+    ctx: str,
+    group: str,
+    version: str,
+    plural: str,
+    namespace: str,
+    name: str,
+    condition_type: str = "Ready",
+    timeout: int = 180,
+) -> dict:
+    """
+    Poll a namespaced custom resource until condition_type == True.
+
+    Determinism: asserts on k8s condition status, not wall-clock time.
+    Raises TimeoutError (caught by pytest as failure) if timeout expires.
+    """
+    co = custom_objects(ctx)
+    deadline = time.monotonic() + timeout
+    last_msg = ""
+    while time.monotonic() < deadline:
+        try:
+            obj = co.get_namespaced_custom_object(group, version, namespace, plural, name)
+            conditions = obj.get("status", {}).get("conditions", [])
+            for cond in conditions:
+                if cond.get("type") == condition_type:
+                    if cond.get("status") == "True":
+                        return obj
+                    last_msg = cond.get("message", "")
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                raise
+        time.sleep(5)
+    raise TimeoutError(
+        f"{plural}/{namespace}/{name} did not reach {condition_type}=True "
+        f"within {timeout}s. Last message: {last_msg}"
+    )
+
+
+def wait_for_cluster_condition(
+    ctx: str,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    condition_type: str = "Ready",
+    timeout: int = 180,
+) -> dict:
+    """Same as wait_for_condition but for cluster-scoped resources."""
+    co = custom_objects(ctx)
+    deadline = time.monotonic() + timeout
+    last_msg = ""
+    while time.monotonic() < deadline:
+        try:
+            obj = co.get_cluster_custom_object(group, version, plural, name)
+            conditions = obj.get("status", {}).get("conditions", [])
+            for cond in conditions:
+                if cond.get("type") == condition_type:
+                    if cond.get("status") == "True":
+                        return obj
+                    last_msg = cond.get("message", "")
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                raise
+        time.sleep(5)
+    raise TimeoutError(
+        f"{plural}/{name} did not reach {condition_type}=True "
+        f"within {timeout}s. Last message: {last_msg}"
+    )
+
+
+def all_flux_resources_ready(ctx: str, cluster_label: str) -> list[str]:
+    """
+    Check all Flux resource types across all namespaces.
+    Returns list of failure messages; empty list means all healthy.
+    """
+    flux_types = [
+        ("kustomize.toolkit.fluxcd.io", "v1", "kustomizations"),
+        ("source.toolkit.fluxcd.io", "v1", "gitrepositories"),
+        ("helm.toolkit.fluxcd.io", "v2", "helmreleases"),
+        ("source.toolkit.fluxcd.io", "v1", "helmrepositories"),
+        ("image.toolkit.fluxcd.io", "v1beta2", "imagerepositories"),
+        ("image.toolkit.fluxcd.io", "v1beta2", "imagepolicies"),
+        ("image.toolkit.fluxcd.io", "v1beta2", "imageupdateautomations"),
+    ]
+    co = custom_objects(ctx)
+    failures = []
+    for group, version, plural in flux_types:
+        try:
+            resources = co.list_cluster_custom_object(group, version, plural)
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                continue  # CRD not installed on this cluster — expected for some types
+            raise
+        for item in resources.get("items", []):
+            meta = item["metadata"]
+            suspended = item.get("spec", {}).get("suspend", False)
+            if suspended:
+                logger.info("[%s] %s/%s/%s SUSPENDED — skipping", cluster_label, plural, meta["namespace"], meta["name"])
+                continue
+            conditions = item.get("status", {}).get("conditions", [])
+            ready = next((c for c in conditions if c.get("type") == "Ready"), None)
+            if not ready:
+                failures.append(f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: no Ready condition")
+            elif ready["status"] != "True":
+                failures.append(
+                    f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: "
+                    f"Ready={ready['status']} — {ready.get('message', '')}"
+                )
+    return failures
+
+
+# ── port-forward context manager ──────────────────────────────────────────────
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def port_forward(ctx: str, namespace: str, resource: str, remote_port: int):
+    """
+    Context manager that port-forwards to a service and yields the base URL.
+    resource can be 'svc/name' or 'pod/name'.
+    """
+    local_port = _free_port()
+    proc = subprocess.Popen(
+        ["kubectl", f"--context={ctx}", "port-forward", resource,
+         f"{local_port}:{remote_port}", "-n", namespace],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait until the port is actually listening
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", local_port), timeout=1):
+                break
+        except OSError:
+            time.sleep(0.5)
+    try:
+        yield f"http://localhost:{local_port}"
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,6 +37,49 @@ def _find_context(suffix: str) -> str | None:
     return None
 
 
+def _fetch_credentials(cluster_name: str) -> bool:
+    """Try to fetch credentials for a GKE cluster using gcloud."""
+    if subprocess.run(["which", "gcloud"], capture_output=True).returncode != 0:
+        return False
+
+    logger.info(f"Context for {cluster_name} not found. Attempting to fetch...")
+    try:
+        cmd = [
+            "gcloud", "container", "clusters", "list",
+            "--filter", f"name~{cluster_name}",
+            "--format", "value(name,zone,project)"
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().splitlines():
+                parts = line.split()
+                if len(parts) >= 3:
+                    name, zone, project = parts[0], parts[1], parts[2]
+                    if name == cluster_name or name.endswith(f"-{cluster_name}"):
+                        logger.info(f"Found cluster {name} in {zone} ({project}). Fetching credentials...")
+                        subprocess.run([
+                            "gcloud", "container", "clusters", "get-credentials",
+                            name, "--zone", zone, "--project", project
+                        ], check=True)
+                        return True
+    except Exception as e:
+        logger.error(f"Failed to fetch credentials for {cluster_name}: {e}")
+    return False
+
+
+def _ensure_context(name: str) -> str | None:
+    ctx = _find_context(name)
+    if ctx and _context_reachable(ctx):
+        return ctx
+
+    if _fetch_credentials(name):
+        ctx = _find_context(name)
+        if ctx and _context_reachable(ctx):
+            return ctx
+
+    return None
+
+
 def _context_reachable(ctx: str) -> bool:
     """Return True if the API server responds within a short timeout."""
     result = subprocess.run(
@@ -58,16 +101,16 @@ def ctx_kind() -> str:
 
 @pytest.fixture(scope="session")
 def ctx_control_plane() -> str:
-    ctx = _find_context("control-plane")
-    if not ctx or not _context_reachable(ctx):
+    ctx = _ensure_context("control-plane")
+    if not ctx:
         pytest.skip("control-plane cluster not available")
     return ctx
 
 
 @pytest.fixture(scope="session")
 def ctx_apps_dev() -> str:
-    ctx = _find_context("apps-dev")
-    if not ctx or not _context_reachable(ctx):
+    ctx = _ensure_context("apps-dev")
+    if not ctx:
         pytest.skip("apps-dev cluster not available")
     return ctx
 
@@ -88,6 +131,46 @@ def custom_objects(ctx: str) -> client.CustomObjectsApi:
 
 def apps_v1(ctx: str) -> client.AppsV1Api:
     return client.AppsV1Api(api_client=k8s_api(ctx))
+
+
+# ── resource helpers ──────────────────────────────────────────────────────────
+
+def get_resource(
+    ctx: str,
+    group: str,
+    version: str,
+    plural: str,
+    namespace: str,
+    name: str,
+) -> dict:
+    """Get a custom resource or fail with a clear message on 404."""
+    co = custom_objects(ctx)
+    try:
+        return co.get_namespaced_custom_object(group, version, namespace, plural, name)
+    except client.exceptions.ApiException as exc:
+        if exc.status == 404:
+            pytest.fail(f"{plural}/{namespace}/{name} not found")
+        raise
+
+
+def assert_resource_ready(
+    ctx: str,
+    group: str,
+    version: str,
+    plural: str,
+    namespace: str,
+    name: str,
+    condition_type: str = "Ready",
+) -> dict:
+    """Read a custom resource once and assert condition_type == True."""
+    obj = get_resource(ctx, group, version, namespace, plural, name)
+    conditions = obj.get("status", {}).get("conditions", [])
+    for cond in conditions:
+        if cond.get("type") == condition_type:
+            assert cond.get("status") == "True", \
+                f"{plural}/{namespace}/{name} is {condition_type}={cond.get('status')} - {cond.get('message', '')}"
+            return obj
+    pytest.fail(f"{plural}/{namespace}/{name} has no {condition_type} condition")
 
 
 # ── condition polling ─────────────────────────────────────────────────────────

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -279,11 +279,11 @@ def all_flux_resources_ready(ctx: str, cluster_label: str) -> list[str]:
             if not ready:
                 # If no Ready condition, report the last available status/message if any
                 status_str = f"Conditions: {[c.get('type') for c in conditions]}" if conditions else "No conditions"
-                failures.append(f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: {status_str}")
-            elif ready["status"] != "True":
+                failures.append(f"[{cluster_label}] {plural}/{meta.get('namespace', 'default')}/{meta.get('name', 'unknown')}: {status_str}")
+            elif ready.get("status") != "True":
                 failures.append(
-                    f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: "
-                    f"Ready={ready['status']} — {ready.get('message', '')}"
+                    f"[{cluster_label}] {plural}/{meta.get('namespace', 'default')}/{meta.get('name', 'unknown')}: "
+                    f"Ready={ready.get('status')} — {ready.get('message', '')}"
                 )
     return failures
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -89,6 +89,136 @@ def _context_reachable(ctx: str) -> bool:
     return result.returncode == 0
 
 
+def wait_for_deletion(
+    ctx: str,
+    group: str,
+    version: str,
+    plural: str,
+    namespace: str,
+    name: str,
+    timeout: int = 60,
+) -> None:
+    """Poll until a custom resource returns 404 (Not Found)."""
+    co = custom_objects(ctx)
+    deadline = time.monotonic() + timeout
+    logger.info(f"Waiting for deletion of {plural}/{namespace}/{name} (timeout {timeout}s)...")
+    while time.monotonic() < deadline:
+        try:
+            co.get_namespaced_custom_object(group, version, namespace, plural, name)
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                logger.info(f"OK: {plural}/{namespace}/{name} deleted")
+                return
+            raise
+        time.sleep(1)
+    raise TimeoutError(f"{plural}/{namespace}/{name} was not deleted within {timeout}s")
+
+
+def wait_for_deployment_ready(
+    ctx: str,
+    namespace: str,
+    name: str,
+    timeout: int = 120,
+) -> None:
+    """Poll until a deployment has readyReplicas >= replicas."""
+    api = apps_v1(ctx)
+    deadline = time.monotonic() + timeout
+    start_time = time.monotonic()
+
+    logger.info(f"Waiting for deployment {namespace}/{name} to be ready (timeout {timeout}s)...")
+
+    while time.monotonic() < deadline:
+        try:
+            d = api.read_namespaced_deployment(name, namespace)
+            desired = d.spec.replicas or 1
+            ready = d.status.ready_replicas or 0
+            if ready >= desired:
+                elapsed = int(time.monotonic() - start_time)
+                logger.info(f"OK: deployment {namespace}/{name} is ready ({ready}/{desired}) after {elapsed}s")
+                return
+
+            elapsed = int(time.monotonic() - start_time)
+            if elapsed % 10 == 0:
+                logger.info(f"Still waiting for deployment {namespace}/{name} ({elapsed}s elapsed). Status: ready={ready}/{desired}")
+
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                raise
+
+        time.sleep(1)
+
+    raise TimeoutError(f"Deployment {namespace}/{name} did not become ready within {timeout}s")
+
+
+def wait_for_nodes_ready(
+    ctx: str,
+    timeout: int = 300,
+) -> None:
+    """Poll until all nodes in the cluster are Ready."""
+    v1 = core_v1(ctx)
+    deadline = time.monotonic() + timeout
+    start_time = time.monotonic()
+
+    logger.info(f"Waiting for all nodes in {ctx} to be Ready (timeout {timeout}s)...")
+
+    while time.monotonic() < deadline:
+        try:
+            nodes = v1.list_node()
+            if not nodes.items:
+                 time.sleep(2)
+                 continue
+
+            unready = []
+            for node in nodes.items:
+                ready = next((c for c in node.status.conditions if c.type == "Ready"), None)
+                if not ready or ready.status != "True":
+                    unready.append(node.metadata.name)
+
+            if not unready:
+                elapsed = int(time.monotonic() - start_time)
+                logger.info(f"OK: all {len(nodes.items)} nodes are Ready after {elapsed}s")
+                return
+
+            elapsed = int(time.monotonic() - start_time)
+            if elapsed % 10 == 0:
+                logger.info(f"Still waiting for {len(unready)} nodes to be Ready: {unready}")
+
+        except Exception as e:
+            logger.warning(f"Error checking nodes: {e}")
+
+        time.sleep(2)
+
+    raise TimeoutError(f"Nodes in {ctx} did not become Ready within {timeout}s")
+
+
+def wait_for_flux_ready(
+    ctx: str,
+    cluster_label: str,
+    timeout: int = 180,
+) -> None:
+    """Poll until all Flux resources in the cluster are Ready."""
+    deadline = time.monotonic() + timeout
+    start_time = time.monotonic()
+
+    logger.info(f"Waiting for all Flux resources in {cluster_label} to be Ready (timeout {timeout}s)...")
+
+    while time.monotonic() < deadline:
+        failures = all_flux_resources_ready(ctx, cluster_label)
+        if not failures:
+            elapsed = int(time.monotonic() - start_time)
+            logger.info(f"OK: all Flux resources in {cluster_label} are Ready after {elapsed}s")
+            return
+
+        elapsed = int(time.monotonic() - start_time)
+        if elapsed % 20 == 0:
+            logger.info(f"Still waiting for Flux in {cluster_label} ({elapsed}s elapsed). {len(failures)} issues found.")
+
+        time.sleep(5) # Flux sync is slow, 5s is fine
+
+    failures = all_flux_resources_ready(ctx, cluster_label)
+    raise TimeoutError(f"Flux resources in {cluster_label} did not become Ready:\n" + "\n".join(failures))
+
+
 # ── session-scoped context fixtures ──────────────────────────────────────────
 
 @pytest.fixture(scope="session")
@@ -194,6 +324,10 @@ def wait_for_condition(
     co = custom_objects(ctx)
     deadline = time.monotonic() + timeout
     last_msg = ""
+    start_time = time.monotonic()
+
+    logger.info(f"Waiting for {plural}/{namespace}/{name} to reach {condition_type}=True (timeout {timeout}s)...")
+
     while time.monotonic() < deadline:
         try:
             obj = co.get_namespaced_custom_object(group, version, namespace, plural, name)
@@ -201,12 +335,23 @@ def wait_for_condition(
             for cond in conditions:
                 if cond.get("type") == condition_type:
                     if cond.get("status") == "True":
+                        elapsed = int(time.monotonic() - start_time)
+                        logger.info(f"OK: {plural}/{namespace}/{name} reached {condition_type}=True after {elapsed}s")
                         return obj
                     last_msg = cond.get("message", "")
+
+            # Progress indication
+            elapsed = int(time.monotonic() - start_time)
+            if elapsed % 10 == 0:  # Log every 10 seconds to avoid noise
+                 logger.info(f"Still waiting for {plural}/{name} ({elapsed}s elapsed). Status: {condition_type}=False. Message: {last_msg}")
+
         except client.exceptions.ApiException as exc:
             if exc.status != 404:
                 raise
-        time.sleep(5)
+            last_msg = "Resource not found"
+
+        time.sleep(1)
+
     raise TimeoutError(
         f"{plural}/{namespace}/{name} did not reach {condition_type}=True "
         f"within {timeout}s. Last message: {last_msg}"
@@ -226,6 +371,10 @@ def wait_for_cluster_condition(
     co = custom_objects(ctx)
     deadline = time.monotonic() + timeout
     last_msg = ""
+    start_time = time.monotonic()
+
+    logger.info(f"Waiting for {plural}/{name} to reach {condition_type}=True (timeout {timeout}s)...")
+
     while time.monotonic() < deadline:
         try:
             obj = co.get_cluster_custom_object(group, version, plural, name)
@@ -233,12 +382,23 @@ def wait_for_cluster_condition(
             for cond in conditions:
                 if cond.get("type") == condition_type:
                     if cond.get("status") == "True":
+                        elapsed = int(time.monotonic() - start_time)
+                        logger.info(f"OK: {plural}/{name} reached {condition_type}=True after {elapsed}s")
                         return obj
                     last_msg = cond.get("message", "")
+
+            # Progress indication
+            elapsed = int(time.monotonic() - start_time)
+            if elapsed % 10 == 0:
+                 logger.info(f"Still waiting for {plural}/{name} ({elapsed}s elapsed). Status: {condition_type}=False. Message: {last_msg}")
+
         except client.exceptions.ApiException as exc:
             if exc.status != 404:
                 raise
-        time.sleep(5)
+            last_msg = "Resource not found"
+
+        time.sleep(1)
+
     raise TimeoutError(
         f"{plural}/{name} did not reach {condition_type}=True "
         f"within {timeout}s. Last message: {last_msg}"
@@ -306,17 +466,39 @@ def port_forward(ctx: str, namespace: str, resource: str, remote_port: int):
     proc = subprocess.Popen(
         ["kubectl", f"--context={ctx}", "port-forward", resource,
          f"{local_port}:{remote_port}", "-n", namespace],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
+
     # Wait until the port is actually listening
     deadline = time.monotonic() + 15
+    connected = False
+
+    logger.info(f"Setting up port-forward to {resource} in {namespace} (local:{local_port} -> remote:{remote_port})...")
+
     while time.monotonic() < deadline:
+        # Check if process is still running
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            raise RuntimeError(
+                f"kubectl port-forward failed immediately: {stderr or stdout}"
+            )
+
         try:
             with socket.create_connection(("localhost", local_port), timeout=1):
+                connected = True
                 break
         except OSError:
             time.sleep(0.5)
+
+    if not connected:
+        proc.terminate()
+        proc.wait()
+        raise TimeoutError(
+            f"Failed to connect to {resource} via port-forward within 15s"
+        )
+
     try:
         yield f"http://localhost:{local_port}"
     finally:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -163,7 +163,7 @@ def assert_resource_ready(
     condition_type: str = "Ready",
 ) -> dict:
     """Read a custom resource once and assert condition_type == True."""
-    obj = get_resource(ctx, group, version, namespace, plural, name)
+    obj = get_resource(ctx, group, version, plural, namespace, name)
     conditions = obj.get("status", {}).get("conditions", [])
     for cond in conditions:
         if cond.get("type") == condition_type:
@@ -277,7 +277,9 @@ def all_flux_resources_ready(ctx: str, cluster_label: str) -> list[str]:
             conditions = item.get("status", {}).get("conditions", [])
             ready = next((c for c in conditions if c.get("type") == "Ready"), None)
             if not ready:
-                failures.append(f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: no Ready condition")
+                # If no Ready condition, report the last available status/message if any
+                status_str = f"Conditions: {[c.get('type') for c in conditions]}" if conditions else "No conditions"
+                failures.append(f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: {status_str}")
             elif ready["status"] != "True":
                 failures.append(
                     f"[{cluster_label}] {plural}/{meta['namespace']}/{meta['name']}: "

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+timeout = 600
+timeout_method = thread
+log_cli = true
+log_cli_level = INFO
+markers =
+    kind: tests targeting the kind bootstrap cluster
+    control_plane: tests targeting the GKE control-plane cluster
+    apps_dev: tests targeting the GKE apps-dev workload cluster
+    flux: Flux GitOps resource health checks
+    crossplane: Crossplane provider/XR checks
+    kagent: kagent agent framework tests
+    litmus: LitmusChaos experiment tests
+    tenants: tenant workload tests
+    slow: tests with long polling timeouts (chaos experiments)

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,4 @@
+kubernetes>=28.1.0
+pytest>=7.4.0
+pytest-timeout>=2.2.0
+requests>=2.31.0

--- a/tests/e2e/test_crossplane.py
+++ b/tests/e2e/test_crossplane.py
@@ -10,7 +10,7 @@ Checks:
 
 import pytest
 from kubernetes import client
-from conftest import custom_objects, wait_for_condition, wait_for_cluster_condition
+from conftest import custom_objects
 
 
 XRD_GROUP = "platform.tornado-demo.io"

--- a/tests/e2e/test_crossplane.py
+++ b/tests/e2e/test_crossplane.py
@@ -1,0 +1,109 @@
+"""
+Crossplane provider and composite resource health.
+
+Checks:
+  - All providers in Installed+Healthy state on kind and control-plane
+  - GKECluster XR for control-plane is Ready (on kind)
+  - GKECluster XR for apps-dev is Ready (on control-plane)
+  - No Crossplane composites exist on apps-dev (architecture constraint)
+"""
+
+import pytest
+from kubernetes import client
+from conftest import custom_objects, wait_for_condition, wait_for_cluster_condition
+
+
+XRD_GROUP = "platform.tornado-demo.io"
+XRD_VERSION = "v1alpha1"
+XRD_PLURAL = "gkeclusters"
+
+
+def _providers_healthy(ctx: str, cluster_label: str) -> None:
+    co = custom_objects(ctx)
+    providers = co.list_cluster_custom_object("pkg.crossplane.io", "v1", "providers")
+    assert providers["items"], f"[{cluster_label}] no Crossplane providers found"
+    failures = []
+    for p in providers["items"]:
+        name = p["metadata"]["name"]
+        conditions = p.get("status", {}).get("conditions", [])
+        installed = next((c for c in conditions if c.get("type") == "Installed"), None)
+        healthy = next((c for c in conditions if c.get("type") == "Healthy"), None)
+        if not installed or installed.get("status") != "True":
+            failures.append(f"{name}: not Installed ({installed})")
+        elif not healthy or healthy.get("status") != "True":
+            failures.append(f"{name}: not Healthy ({healthy})")
+    assert not failures, f"[{cluster_label}] provider issues:\n" + "\n".join(failures)
+
+
+@pytest.mark.kind
+@pytest.mark.crossplane
+def test_crossplane_providers_healthy_kind(ctx_kind):
+    _providers_healthy(ctx_kind, "kind")
+
+
+@pytest.mark.control_plane
+@pytest.mark.crossplane
+def test_crossplane_providers_healthy_control_plane(ctx_control_plane):
+    _providers_healthy(ctx_control_plane, "control-plane")
+
+
+@pytest.mark.kind
+@pytest.mark.crossplane
+def test_gkecluster_control_plane_ready(ctx_kind):
+    """control-plane GKECluster XR must be Synced+Ready on kind."""
+    co = custom_objects(ctx_kind)
+    clusters = co.list_namespaced_custom_object(
+        XRD_GROUP, XRD_VERSION, "control-plane", XRD_PLURAL
+    )
+    items = clusters.get("items", [])
+    assert items, "No GKECluster XR in namespace 'control-plane' on kind"
+    failures = []
+    for xr in items:
+        name = xr["metadata"]["name"]
+        conditions = xr.get("status", {}).get("conditions", [])
+        ready = next((c for c in conditions if c.get("type") == "Ready"), None)
+        synced = next((c for c in conditions if c.get("type") == "Synced"), None)
+        if not ready or ready.get("status") != "True":
+            failures.append(f"{name}: Ready={ready}")
+        if not synced or synced.get("status") != "True":
+            failures.append(f"{name}: Synced={synced}")
+    assert not failures, "GKECluster XR(s) not ready on kind:\n" + "\n".join(failures)
+
+
+@pytest.mark.control_plane
+@pytest.mark.crossplane
+def test_gkecluster_apps_dev_ready(ctx_control_plane):
+    """apps-dev GKECluster XR must be Synced+Ready on control-plane."""
+    co = custom_objects(ctx_control_plane)
+    clusters = co.list_namespaced_custom_object(
+        XRD_GROUP, XRD_VERSION, "apps-dev", XRD_PLURAL
+    )
+    items = clusters.get("items", [])
+    assert items, "No GKECluster XR in namespace 'apps-dev' on control-plane"
+    failures = []
+    for xr in items:
+        name = xr["metadata"]["name"]
+        conditions = xr.get("status", {}).get("conditions", [])
+        ready = next((c for c in conditions if c.get("type") == "Ready"), None)
+        synced = next((c for c in conditions if c.get("type") == "Synced"), None)
+        if not ready or ready.get("status") != "True":
+            failures.append(f"{name}: Ready={ready}")
+        if not synced or synced.get("status") != "True":
+            failures.append(f"{name}: Synced={synced}")
+    assert not failures, "GKECluster XR(s) not ready on control-plane:\n" + "\n".join(failures)
+
+
+@pytest.mark.apps_dev
+@pytest.mark.crossplane
+def test_no_composites_on_apps_dev(ctx_apps_dev):
+    """Workload cluster must not manage infrastructure composites."""
+    co = custom_objects(ctx_apps_dev)
+    try:
+        xrs = co.list_cluster_custom_object(XRD_GROUP, XRD_VERSION, XRD_PLURAL)
+        assert not xrs.get("items"), \
+            f"GKECluster XRs found in apps-dev — workload cluster must not manage infra"
+    except client.exceptions.ApiException as exc:
+        if exc.status == 404:
+            pass  # XRD not installed — correct for workload cluster
+        else:
+            raise

--- a/tests/e2e/test_crossplane.py
+++ b/tests/e2e/test_crossplane.py
@@ -8,10 +8,12 @@ Checks:
   - No Crossplane composites exist on apps-dev (architecture constraint)
 """
 
+import logging
 import pytest
 from kubernetes import client
-from conftest import custom_objects
+from conftest import custom_objects, wait_for_condition, wait_for_cluster_condition
 
+logger = logging.getLogger(__name__)
 
 XRD_GROUP = "platform.tornado-demo.io"
 XRD_VERSION = "v1alpha1"
@@ -22,17 +24,18 @@ def _providers_healthy(ctx: str, cluster_label: str) -> None:
     co = custom_objects(ctx)
     providers = co.list_cluster_custom_object("pkg.crossplane.io", "v1", "providers")
     assert providers["items"], f"[{cluster_label}] no Crossplane providers found"
-    failures = []
+    
     for p in providers["items"]:
         name = p["metadata"]["name"]
-        conditions = p.get("status", {}).get("conditions", [])
-        installed = next((c for c in conditions if c.get("type") == "Installed"), None)
-        healthy = next((c for c in conditions if c.get("type") == "Healthy"), None)
-        if not installed or installed.get("status") != "True":
-            failures.append(f"{name}: not Installed ({installed})")
-        elif not healthy or healthy.get("status") != "True":
-            failures.append(f"{name}: not Healthy ({healthy})")
-    assert not failures, f"[{cluster_label}] provider issues:\n" + "\n".join(failures)
+        # Wait for both Installed and Healthy conditions
+        wait_for_cluster_condition(
+            ctx, "pkg.crossplane.io", "v1", "providers", name,
+            condition_type="Installed", timeout=60
+        )
+        wait_for_cluster_condition(
+            ctx, "pkg.crossplane.io", "v1", "providers", name,
+            condition_type="Healthy", timeout=60
+        )
 
 
 @pytest.mark.kind
@@ -51,46 +54,29 @@ def test_crossplane_providers_healthy_control_plane(ctx_control_plane):
 @pytest.mark.crossplane
 def test_gkecluster_control_plane_ready(ctx_kind):
     """control-plane GKECluster XR must be Synced+Ready on kind."""
-    co = custom_objects(ctx_kind)
-    clusters = co.list_namespaced_custom_object(
-        XRD_GROUP, XRD_VERSION, "control-plane", XRD_PLURAL
+    # We expect exactly one XR in this namespace
+    wait_for_condition(
+        ctx_kind, XRD_GROUP, XRD_VERSION, XRD_PLURAL,
+        "control-plane", "control-plane", condition_type="Ready"
     )
-    items = clusters.get("items", [])
-    assert items, "No GKECluster XR in namespace 'control-plane' on kind"
-    failures = []
-    for xr in items:
-        name = xr["metadata"]["name"]
-        conditions = xr.get("status", {}).get("conditions", [])
-        ready = next((c for c in conditions if c.get("type") == "Ready"), None)
-        synced = next((c for c in conditions if c.get("type") == "Synced"), None)
-        if not ready or ready.get("status") != "True":
-            failures.append(f"{name}: Ready={ready}")
-        if not synced or synced.get("status") != "True":
-            failures.append(f"{name}: Synced={synced}")
-    assert not failures, "GKECluster XR(s) not ready on kind:\n" + "\n".join(failures)
+    wait_for_condition(
+        ctx_kind, XRD_GROUP, XRD_VERSION, XRD_PLURAL,
+        "control-plane", "control-plane", condition_type="Synced"
+    )
 
 
 @pytest.mark.control_plane
 @pytest.mark.crossplane
 def test_gkecluster_apps_dev_ready(ctx_control_plane):
     """apps-dev GKECluster XR must be Synced+Ready on control-plane."""
-    co = custom_objects(ctx_control_plane)
-    clusters = co.list_namespaced_custom_object(
-        XRD_GROUP, XRD_VERSION, "apps-dev", XRD_PLURAL
+    wait_for_condition(
+        ctx_control_plane, XRD_GROUP, XRD_VERSION, XRD_PLURAL,
+        "apps-dev", "apps-dev", condition_type="Ready"
     )
-    items = clusters.get("items", [])
-    assert items, "No GKECluster XR in namespace 'apps-dev' on control-plane"
-    failures = []
-    for xr in items:
-        name = xr["metadata"]["name"]
-        conditions = xr.get("status", {}).get("conditions", [])
-        ready = next((c for c in conditions if c.get("type") == "Ready"), None)
-        synced = next((c for c in conditions if c.get("type") == "Synced"), None)
-        if not ready or ready.get("status") != "True":
-            failures.append(f"{name}: Ready={ready}")
-        if not synced or synced.get("status") != "True":
-            failures.append(f"{name}: Synced={synced}")
-    assert not failures, "GKECluster XR(s) not ready on control-plane:\n" + "\n".join(failures)
+    wait_for_condition(
+        ctx_control_plane, XRD_GROUP, XRD_VERSION, XRD_PLURAL,
+        "apps-dev", "apps-dev", condition_type="Synced"
+    )
 
 
 @pytest.mark.apps_dev

--- a/tests/e2e/test_fleet.py
+++ b/tests/e2e/test_fleet.py
@@ -6,35 +6,22 @@ All assertions use k8s node conditions — deterministic, no timing dependency.
 
 import pytest
 from kubernetes import client
-from conftest import core_v1
-
-
-def _nodes_ready(ctx: str, cluster_label: str) -> None:
-    v1 = core_v1(ctx)
-    nodes = v1.list_node()
-    assert nodes.items, f"[{cluster_label}] no nodes found"
-    failures = []
-    for node in nodes.items:
-        ready = next((c for c in node.status.conditions if c.type == "Ready"), None)
-        if not ready or ready.status != "True":
-            msg = ready.message if ready else "no Ready condition"
-            failures.append(f"{node.metadata.name}: {msg}")
-    assert not failures, f"[{cluster_label}] nodes not Ready:\n" + "\n".join(failures)
+from conftest import core_v1, wait_for_nodes_ready
 
 
 @pytest.mark.kind
 def test_kind_nodes_ready(ctx_kind):
-    _nodes_ready(ctx_kind, "kind")
+    wait_for_nodes_ready(ctx_kind)
 
 
 @pytest.mark.control_plane
 def test_control_plane_nodes_ready(ctx_control_plane):
-    _nodes_ready(ctx_control_plane, "control-plane")
+    wait_for_nodes_ready(ctx_control_plane)
 
 
 @pytest.mark.apps_dev
 def test_apps_dev_nodes_ready(ctx_apps_dev):
-    _nodes_ready(ctx_apps_dev, "apps-dev")
+    wait_for_nodes_ready(ctx_apps_dev)
 
 
 @pytest.mark.control_plane

--- a/tests/e2e/test_fleet.py
+++ b/tests/e2e/test_fleet.py
@@ -1,0 +1,64 @@
+"""
+Fleet-level health: cluster reachability and node readiness.
+
+All assertions use k8s node conditions — deterministic, no timing dependency.
+"""
+
+import pytest
+from kubernetes import client
+from conftest import core_v1
+
+
+def _nodes_ready(ctx: str, cluster_label: str) -> None:
+    v1 = core_v1(ctx)
+    nodes = v1.list_node()
+    assert nodes.items, f"[{cluster_label}] no nodes found"
+    failures = []
+    for node in nodes.items:
+        ready = next((c for c in node.status.conditions if c.type == "Ready"), None)
+        if not ready or ready.status != "True":
+            msg = ready.message if ready else "no Ready condition"
+            failures.append(f"{node.metadata.name}: {msg}")
+    assert not failures, f"[{cluster_label}] nodes not Ready:\n" + "\n".join(failures)
+
+
+@pytest.mark.kind
+def test_kind_nodes_ready(ctx_kind):
+    _nodes_ready(ctx_kind, "kind")
+
+
+@pytest.mark.control_plane
+def test_control_plane_nodes_ready(ctx_control_plane):
+    _nodes_ready(ctx_control_plane, "control-plane")
+
+
+@pytest.mark.apps_dev
+def test_apps_dev_nodes_ready(ctx_apps_dev):
+    _nodes_ready(ctx_apps_dev, "apps-dev")
+
+
+@pytest.mark.control_plane
+def test_crossplane_not_in_apps_dev(ctx_apps_dev):
+    """Architectural constraint: workload cluster must not run Crossplane."""
+    v1 = core_v1(ctx_apps_dev)
+    namespaces = [ns.metadata.name for ns in v1.list_namespace().items]
+    assert "crossplane-system" not in namespaces, \
+        "crossplane-system namespace found in apps-dev — violates architecture"
+
+
+@pytest.mark.kind
+def test_kind_has_crossplane(ctx_kind):
+    """Bootstrap cluster must have crossplane-system."""
+    v1 = core_v1(ctx_kind)
+    namespaces = [ns.metadata.name for ns in v1.list_namespace().items]
+    assert "crossplane-system" in namespaces, \
+        "crossplane-system not found on kind — Crossplane not installed"
+
+
+@pytest.mark.control_plane
+def test_control_plane_has_crossplane(ctx_control_plane):
+    """Control-plane must have crossplane-system."""
+    v1 = core_v1(ctx_control_plane)
+    namespaces = [ns.metadata.name for ns in v1.list_namespace().items]
+    assert "crossplane-system" in namespaces, \
+        "crossplane-system not found on control-plane — Crossplane not installed"

--- a/tests/e2e/test_flux.py
+++ b/tests/e2e/test_flux.py
@@ -1,0 +1,30 @@
+"""
+Flux GitOps health across all clusters.
+
+Determinism: asserts on .status.conditions[Ready].status which is a stable
+k8s API contract. Suspended resources are explicitly skipped, not failed.
+"""
+
+import pytest
+from conftest import all_flux_resources_ready
+
+
+@pytest.mark.kind
+@pytest.mark.flux
+def test_flux_healthy_kind(ctx_kind):
+    failures = all_flux_resources_ready(ctx_kind, "kind")
+    assert not failures, "Flux resources unhealthy on kind:\n" + "\n".join(failures)
+
+
+@pytest.mark.control_plane
+@pytest.mark.flux
+def test_flux_healthy_control_plane(ctx_control_plane):
+    failures = all_flux_resources_ready(ctx_control_plane, "control-plane")
+    assert not failures, "Flux resources unhealthy on control-plane:\n" + "\n".join(failures)
+
+
+@pytest.mark.apps_dev
+@pytest.mark.flux
+def test_flux_healthy_apps_dev(ctx_apps_dev):
+    failures = all_flux_resources_ready(ctx_apps_dev, "apps-dev")
+    assert not failures, "Flux resources unhealthy on apps-dev:\n" + "\n".join(failures)

--- a/tests/e2e/test_flux.py
+++ b/tests/e2e/test_flux.py
@@ -6,25 +6,22 @@ k8s API contract. Suspended resources are explicitly skipped, not failed.
 """
 
 import pytest
-from conftest import all_flux_resources_ready
+from conftest import wait_for_flux_ready
 
 
 @pytest.mark.kind
 @pytest.mark.flux
 def test_flux_healthy_kind(ctx_kind):
-    failures = all_flux_resources_ready(ctx_kind, "kind")
-    assert not failures, "Flux resources unhealthy on kind:\n" + "\n".join(failures)
+    wait_for_flux_ready(ctx_kind, "kind")
 
 
 @pytest.mark.control_plane
 @pytest.mark.flux
 def test_flux_healthy_control_plane(ctx_control_plane):
-    failures = all_flux_resources_ready(ctx_control_plane, "control-plane")
-    assert not failures, "Flux resources unhealthy on control-plane:\n" + "\n".join(failures)
+    wait_for_flux_ready(ctx_control_plane, "control-plane")
 
 
 @pytest.mark.apps_dev
 @pytest.mark.flux
 def test_flux_healthy_apps_dev(ctx_apps_dev):
-    failures = all_flux_resources_ready(ctx_apps_dev, "apps-dev")
-    assert not failures, "Flux resources unhealthy on apps-dev:\n" + "\n".join(failures)
+    wait_for_flux_ready(ctx_apps_dev, "apps-dev")

--- a/tests/e2e/test_kagent.py
+++ b/tests/e2e/test_kagent.py
@@ -1,0 +1,124 @@
+"""
+kagent functional tests on the apps-dev cluster.
+
+Determinism:
+  - HelmRelease and pod checks assert on k8s conditions/phases, not timing.
+  - API test asserts on HTTP status + JSON schema (list structure), NEVER on
+    LLM response content — the same request always returns the same schema.
+"""
+
+import logging
+import time
+
+import pytest
+import requests
+from kubernetes import client
+from conftest import (
+    custom_objects,
+    core_v1,
+    apps_v1,
+    wait_for_condition,
+    port_forward,
+)
+
+logger = logging.getLogger(__name__)
+
+KAGENT_NAMESPACE = "kagent-system"
+KAGENT_SERVICE = "kagent"
+KAGENT_API_PORT = 8083
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_kagent_crds_helmrelease_ready(ctx_apps_dev):
+    """kagent-crds HelmRelease must be Ready before kagent itself."""
+    wait_for_condition(
+        ctx_apps_dev,
+        "helm.toolkit.fluxcd.io", "v2", "helmreleases",
+        KAGENT_NAMESPACE, "kagent-crds",
+        timeout=300,
+    )
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_kagent_helmrelease_ready(ctx_apps_dev):
+    wait_for_condition(
+        ctx_apps_dev,
+        "helm.toolkit.fluxcd.io", "v2", "helmreleases",
+        KAGENT_NAMESPACE, "kagent",
+        timeout=300,
+    )
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_kagent_pods_running(ctx_apps_dev):
+    """At least one kagent controller pod must be Running."""
+    v1 = core_v1(ctx_apps_dev)
+    pods = v1.list_namespaced_pod(
+        KAGENT_NAMESPACE,
+        label_selector="app.kubernetes.io/name=kagent",
+    )
+    running = [p for p in pods.items if p.status.phase == "Running"]
+    assert running, (
+        f"No Running kagent pods in {KAGENT_NAMESPACE}. "
+        f"Found: {[(p.metadata.name, p.status.phase) for p in pods.items]}"
+    )
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_kagent_model_config_exists(ctx_apps_dev):
+    """ModelConfig for Claude must exist in kagent-system."""
+    co = custom_objects(ctx_apps_dev)
+    obj = co.get_namespaced_custom_object(
+        "kagent.dev", "v1alpha2",
+        KAGENT_NAMESPACE, "modelconfigs",
+        "claude-model-config",
+    )
+    assert obj["spec"]["provider"] == "Anthropic"
+    assert obj["spec"]["apiKeySecret"] == "kagent-anthropic"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_mcp_website_fetcher_pod_running(ctx_apps_dev):
+    """Tutorial MCP tool server must be Running."""
+    v1 = core_v1(ctx_apps_dev)
+    pods = v1.list_namespaced_pod(
+        "kagent",
+        label_selector="app=mcp-website-fetcher",
+    )
+    running = [p for p in pods.items if p.status.phase == "Running"]
+    assert running, "mcp-website-fetcher pod not Running in kagent namespace"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_mcp_toolserver_resource_exists(ctx_apps_dev):
+    """ToolServer CRD object for mcp-toolserver must exist."""
+    co = custom_objects(ctx_apps_dev)
+    obj = co.get_namespaced_custom_object(
+        "kagent.dev", "v1alpha1",
+        "kagent", "toolservers",
+        "mcp-toolserver",
+    )
+    assert obj["spec"]["config"]["sse"]["url"], "ToolServer has no SSE URL"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.kagent
+def test_kagent_api_agents_endpoint(ctx_apps_dev):
+    """
+    kagent REST API must respond with a valid list at GET /api/v1/agents.
+
+    Determinism: we assert HTTP 200 + JSON list schema.
+    We do NOT assert on list contents — agents can be added/removed.
+    """
+    with port_forward(ctx_apps_dev, KAGENT_NAMESPACE, f"svc/{KAGENT_SERVICE}", KAGENT_API_PORT) as base_url:
+        resp = requests.get(f"{base_url}/api/v1/agents", timeout=15)
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text[:200]}"
+    body = resp.json()
+    assert isinstance(body, list), f"Expected JSON list, got {type(body)}: {str(body)[:200]}"
+    logger.info("kagent /api/v1/agents returned %d agent(s)", len(body))

--- a/tests/e2e/test_kagent.py
+++ b/tests/e2e/test_kagent.py
@@ -18,6 +18,8 @@ from conftest import (
     core_v1,
     apps_v1,
     wait_for_condition,
+    assert_resource_ready,
+    get_resource,
     port_forward,
 )
 
@@ -32,22 +34,20 @@ KAGENT_API_PORT = 8083
 @pytest.mark.kagent
 def test_kagent_crds_helmrelease_ready(ctx_apps_dev):
     """kagent-crds HelmRelease must be Ready before kagent itself."""
-    wait_for_condition(
+    assert_resource_ready(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         KAGENT_NAMESPACE, "kagent-crds",
-        timeout=300,
     )
 
 
 @pytest.mark.apps_dev
 @pytest.mark.kagent
 def test_kagent_helmrelease_ready(ctx_apps_dev):
-    wait_for_condition(
+    assert_resource_ready(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         KAGENT_NAMESPACE, "kagent",
-        timeout=300,
     )
 
 
@@ -71,8 +71,8 @@ def test_kagent_pods_running(ctx_apps_dev):
 @pytest.mark.kagent
 def test_kagent_model_config_exists(ctx_apps_dev):
     """ModelConfig for Claude must exist in kagent-system."""
-    co = custom_objects(ctx_apps_dev)
-    obj = co.get_namespaced_custom_object(
+    obj = get_resource(
+        ctx_apps_dev,
         "kagent.dev", "v1alpha2",
         KAGENT_NAMESPACE, "modelconfigs",
         "claude-model-config",
@@ -98,8 +98,8 @@ def test_mcp_website_fetcher_pod_running(ctx_apps_dev):
 @pytest.mark.kagent
 def test_mcp_toolserver_resource_exists(ctx_apps_dev):
     """ToolServer CRD object for mcp-toolserver must exist."""
-    co = custom_objects(ctx_apps_dev)
-    obj = co.get_namespaced_custom_object(
+    obj = get_resource(
+        ctx_apps_dev,
         "kagent.dev", "v1alpha1",
         "kagent", "toolservers",
         "mcp-toolserver",

--- a/tests/e2e/test_kagent.py
+++ b/tests/e2e/test_kagent.py
@@ -34,7 +34,7 @@ KAGENT_API_PORT = 8083
 @pytest.mark.kagent
 def test_kagent_crds_helmrelease_ready(ctx_apps_dev):
     """kagent-crds HelmRelease must be Ready before kagent itself."""
-    assert_resource_ready(
+    wait_for_condition(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         KAGENT_NAMESPACE, "kagent-crds",
@@ -44,7 +44,7 @@ def test_kagent_crds_helmrelease_ready(ctx_apps_dev):
 @pytest.mark.apps_dev
 @pytest.mark.kagent
 def test_kagent_helmrelease_ready(ctx_apps_dev):
-    assert_resource_ready(
+    wait_for_condition(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         KAGENT_NAMESPACE, "kagent",

--- a/tests/e2e/test_litmus.py
+++ b/tests/e2e/test_litmus.py
@@ -1,0 +1,145 @@
+"""
+LitmusChaos e2e tests on the apps-dev cluster.
+
+Determinism:
+  - Creates a ChaosEngine with fixed, short parameters targeting a known
+    deployment (mcp-website-fetcher, 1 replica). The pod gets deleted and
+    Kubernetes restarts it; Litmus records verdict=Pass when its probes confirm
+    the app recovered within the experiment window.
+  - We poll chaosresult.status.experimentStatus.verdict until it leaves
+    "Awaited" — binary Pass/Fail, no timing assertion.
+  - Engine is cleaned up after the test regardless of outcome.
+"""
+
+import logging
+import time
+
+import pytest
+from kubernetes import client
+from conftest import custom_objects, wait_for_condition
+
+logger = logging.getLogger(__name__)
+
+LITMUS_NS = "litmus"
+ENGINE_NAME = "e2e-pod-delete"
+RESULT_NAME = f"{ENGINE_NAME}-pod-delete"
+
+# Short chaos: 30s total, delete every 10s, single pod target
+_ENGINE_MANIFEST = {
+    "apiVersion": "litmuschaos.io/v1alpha1",
+    "kind": "ChaosEngine",
+    "metadata": {
+        "name": ENGINE_NAME,
+        "namespace": LITMUS_NS,
+    },
+    "spec": {
+        "engineState": "active",
+        "appinfo": {
+            "appns": "kagent",
+            "applabel": "app=mcp-website-fetcher",
+            "appkind": "deployment",
+        },
+        "chaosServiceAccount": "pod-delete-sa",
+        "annotationCheck": "false",
+        "experiments": [{
+            "name": "pod-delete",
+            "spec": {
+                "components": {
+                    "env": [
+                        {"name": "TOTAL_CHAOS_DURATION", "value": "30"},
+                        {"name": "CHAOS_INTERVAL", "value": "10"},
+                        {"name": "FORCE", "value": "true"},
+                        {"name": "PODS_AFFECTED_PERC", "value": "100"},
+                        {"name": "DEFAULT_HEALTH_CHECK", "value": "false"},
+                    ]
+                }
+            },
+        }],
+    },
+}
+
+
+def _delete_engine(co: client.CustomObjectsApi) -> None:
+    try:
+        co.delete_namespaced_custom_object(
+            "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosengines", ENGINE_NAME
+        )
+        logger.info("Deleted ChaosEngine %s", ENGINE_NAME)
+    except client.exceptions.ApiException as exc:
+        if exc.status != 404:
+            logger.warning("Could not delete ChaosEngine: %s", exc)
+
+
+def _delete_result(co: client.CustomObjectsApi) -> None:
+    try:
+        co.delete_namespaced_custom_object(
+            "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosresults", RESULT_NAME
+        )
+    except client.exceptions.ApiException as exc:
+        if exc.status != 404:
+            pass
+
+
+@pytest.mark.apps_dev
+@pytest.mark.litmus
+@pytest.mark.slow
+def test_litmus_installed(ctx_apps_dev):
+    """Litmus CRDs and the pod-delete ChaosExperiment must exist."""
+    co = custom_objects(ctx_apps_dev)
+    exp = co.get_namespaced_custom_object(
+        "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosexperiments", "pod-delete"
+    )
+    assert exp["metadata"]["name"] == "pod-delete"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.litmus
+@pytest.mark.slow
+def test_litmus_pod_delete_passes(ctx_apps_dev):
+    """
+    Run a short pod-delete experiment against mcp-website-fetcher and
+    assert the chaos operator reports verdict=Pass.
+
+    The test confirms the target deployment survives pod deletion — a basic
+    resilience check that is independent of workload logic.
+    """
+    co = custom_objects(ctx_apps_dev)
+
+    # Clean up leftovers from a previous run
+    _delete_engine(co)
+    _delete_result(co)
+    time.sleep(3)
+
+    logger.info("Creating ChaosEngine %s", ENGINE_NAME)
+    co.create_namespaced_custom_object(
+        "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosengines", _ENGINE_MANIFEST
+    )
+
+    verdict = "Awaited"
+    try:
+        # Experiment runs for 30s; allow up to 120s total for runner pod startup + result
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            try:
+                result = co.get_namespaced_custom_object(
+                    "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosresults", RESULT_NAME
+                )
+                verdict = (
+                    result.get("status", {})
+                    .get("experimentStatus", {})
+                    .get("verdict", "Awaited")
+                )
+                logger.info("ChaosResult verdict: %s", verdict)
+                if verdict != "Awaited":
+                    break
+            except client.exceptions.ApiException as exc:
+                if exc.status != 404:
+                    raise
+            time.sleep(5)
+    finally:
+        _delete_engine(co)
+
+    assert verdict == "Pass", (
+        f"ChaosExperiment {ENGINE_NAME} verdict={verdict!r}. "
+        "Check ChaosResult in litmus namespace for details."
+    )

--- a/tests/e2e/test_litmus.py
+++ b/tests/e2e/test_litmus.py
@@ -138,6 +138,7 @@ def test_litmus_pod_delete_passes(ctx_apps_dev):
             time.sleep(5)
     finally:
         _delete_engine(co)
+        _delete_result(co)
 
     assert verdict == "Pass", (
         f"ChaosExperiment {ENGINE_NAME} verdict={verdict!r}. "

--- a/tests/e2e/test_litmus.py
+++ b/tests/e2e/test_litmus.py
@@ -16,7 +16,7 @@ import time
 
 import pytest
 from kubernetes import client
-from conftest import custom_objects, wait_for_condition
+from conftest import custom_objects, wait_for_condition, get_resource
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +85,8 @@ def _delete_result(co: client.CustomObjectsApi) -> None:
 @pytest.mark.slow
 def test_litmus_installed(ctx_apps_dev):
     """Litmus CRDs and the pod-delete ChaosExperiment must exist."""
-    co = custom_objects(ctx_apps_dev)
-    exp = co.get_namespaced_custom_object(
+    exp = get_resource(
+        ctx_apps_dev,
         "litmuschaos.io", "v1alpha1", LITMUS_NS, "chaosexperiments", "pod-delete"
     )
     assert exp["metadata"]["name"] == "pod-delete"

--- a/tests/e2e/test_litmus.py
+++ b/tests/e2e/test_litmus.py
@@ -108,7 +108,15 @@ def test_litmus_pod_delete_passes(ctx_apps_dev):
     # Clean up leftovers from a previous run
     _delete_engine(co)
     _delete_result(co)
-    time.sleep(3)
+
+    # Wait for deletion instead of static sleep
+    try:
+        wait_for_deletion(ctx_apps_dev, "litmuschaos.io", "v1alpha1", "chaosengines", LITMUS_NS, ENGINE_NAME, timeout=30)
+        wait_for_deletion(ctx_apps_dev, "litmuschaos.io", "v1alpha1", "chaosresults", LITMUS_NS, RESULT_NAME, timeout=30)
+    except TimeoutError:
+        # If they were already gone, wait_for_deletion might timeout if it was 404 from start.
+        # But wait_for_deletion handles 404 correctly.
+        pass
 
     logger.info("Creating ChaosEngine %s", ENGINE_NAME)
     co.create_namespaced_custom_object(
@@ -119,6 +127,7 @@ def test_litmus_pod_delete_passes(ctx_apps_dev):
     try:
         # Experiment runs for 30s; allow up to 120s total for runner pod startup + result
         deadline = time.monotonic() + 120
+        start_time = time.monotonic()
         while time.monotonic() < deadline:
             try:
                 result = co.get_namespaced_custom_object(
@@ -129,13 +138,15 @@ def test_litmus_pod_delete_passes(ctx_apps_dev):
                     .get("experimentStatus", {})
                     .get("verdict", "Awaited")
                 )
-                logger.info("ChaosResult verdict: %s", verdict)
+                elapsed = int(time.monotonic() - start_time)
+                if elapsed % 10 == 0:
+                    logger.info("ChaosResult verdict: %s (%ds elapsed)", verdict, elapsed)
                 if verdict != "Awaited":
                     break
             except client.exceptions.ApiException as exc:
                 if exc.status != 404:
                     raise
-            time.sleep(5)
+            time.sleep(1) # Reduced from 5s
     finally:
         _delete_engine(co)
         _delete_result(co)

--- a/tests/e2e/test_tenants.py
+++ b/tests/e2e/test_tenants.py
@@ -10,7 +10,7 @@ import logging
 
 import pytest
 from kubernetes import client
-from conftest import apps_v1, core_v1
+from conftest import apps_v1, core_v1, assert_resource_ready
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,6 @@ def test_tenant_namespaces_labelled(ctx_apps_dev):
 @pytest.mark.tenants
 def test_kgateway_ready(ctx_apps_dev):
     """kgateway HelmRelease must be Ready on apps-dev."""
-    from conftest import assert_resource_ready
     assert_resource_ready(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",

--- a/tests/e2e/test_tenants.py
+++ b/tests/e2e/test_tenants.py
@@ -68,10 +68,9 @@ def test_tenant_namespaces_labelled(ctx_apps_dev):
 @pytest.mark.tenants
 def test_kgateway_ready(ctx_apps_dev):
     """kgateway HelmRelease must be Ready on apps-dev."""
-    from conftest import wait_for_condition
-    wait_for_condition(
+    from conftest import assert_resource_ready
+    assert_resource_ready(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         "kgateway-system", "kgateway",
-        timeout=180,
     )

--- a/tests/e2e/test_tenants.py
+++ b/tests/e2e/test_tenants.py
@@ -10,33 +10,16 @@ import logging
 
 import pytest
 from kubernetes import client
-from conftest import apps_v1, core_v1, assert_resource_ready
+from conftest import apps_v1, core_v1, wait_for_condition, wait_for_deployment_ready
 
 logger = logging.getLogger(__name__)
-
-
-def _deployment_ready(ctx: str, namespace: str, name: str) -> tuple[bool, str]:
-    """Return (ready, reason). A deployment is ready when readyReplicas == replicas."""
-    api = apps_v1(ctx)
-    try:
-        d = api.read_namespaced_deployment(name, namespace)
-    except client.exceptions.ApiException as exc:
-        if exc.status == 404:
-            return False, f"deployment {namespace}/{name} not found"
-        raise
-    desired = d.spec.replicas or 1
-    ready = d.status.ready_replicas or 0
-    if ready >= desired:
-        return True, ""
-    return False, f"ready={ready}/{desired}"
 
 
 @pytest.mark.apps_dev
 @pytest.mark.tenants
 def test_mcp_website_fetcher_deployment_ready(ctx_apps_dev):
     """mcp-website-fetcher in kagent namespace must be fully Ready."""
-    ok, reason = _deployment_ready(ctx_apps_dev, "kagent", "mcp-website-fetcher")
-    assert ok, f"mcp-website-fetcher not ready: {reason}"
+    wait_for_deployment_ready(ctx_apps_dev, "kagent", "mcp-website-fetcher")
 
 
 @pytest.mark.apps_dev
@@ -69,6 +52,26 @@ def test_tenant_namespaces_labelled(ctx_apps_dev):
 def test_kgateway_ready(ctx_apps_dev):
     """kgateway HelmRelease must be Ready on apps-dev."""
     assert_resource_ready(
+        ctx_apps_dev,
+        "helm.toolkit.fluxcd.io", "v2", "helmreleases",
+        "kgateway-system", "kgateway",
+    )
+namespaces with workload-type=application found — "
+                    "tenants may not be deployed yet")
+    # All found namespaces must be Active
+    inactive = [
+        ns.metadata.name
+        for ns in namespaces.items
+        if ns.status.phase != "Active"
+    ]
+    assert not inactive, f"Tenant namespaces not Active: {inactive}"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.tenants
+def test_kgateway_ready(ctx_apps_dev):
+    """kgateway HelmRelease must be Ready on apps-dev."""
+    wait_for_condition(
         ctx_apps_dev,
         "helm.toolkit.fluxcd.io", "v2", "helmreleases",
         "kgateway-system", "kgateway",

--- a/tests/e2e/test_tenants.py
+++ b/tests/e2e/test_tenants.py
@@ -1,0 +1,77 @@
+"""
+Tenant workload health on apps-dev.
+
+Checks deployment readiness for both real tenants (sre) and synthetic
+team tenants. Deterministic: asserts on deployment .status.readyReplicas
+which reflects actual pod health, not scheduling assumptions.
+"""
+
+import logging
+
+import pytest
+from kubernetes import client
+from conftest import apps_v1, core_v1
+
+logger = logging.getLogger(__name__)
+
+
+def _deployment_ready(ctx: str, namespace: str, name: str) -> tuple[bool, str]:
+    """Return (ready, reason). A deployment is ready when readyReplicas == replicas."""
+    api = apps_v1(ctx)
+    try:
+        d = api.read_namespaced_deployment(name, namespace)
+    except client.exceptions.ApiException as exc:
+        if exc.status == 404:
+            return False, f"deployment {namespace}/{name} not found"
+        raise
+    desired = d.spec.replicas or 1
+    ready = d.status.ready_replicas or 0
+    if ready >= desired:
+        return True, ""
+    return False, f"ready={ready}/{desired}"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.tenants
+def test_mcp_website_fetcher_deployment_ready(ctx_apps_dev):
+    """mcp-website-fetcher in kagent namespace must be fully Ready."""
+    ok, reason = _deployment_ready(ctx_apps_dev, "kagent", "mcp-website-fetcher")
+    assert ok, f"mcp-website-fetcher not ready: {reason}"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.tenants
+def test_tenant_namespaces_labelled(ctx_apps_dev):
+    """
+    All namespaces with workload-type=application label must exist.
+    Validates the Flux tenant kustomization applied the namespace manifests.
+    """
+    v1 = core_v1(ctx_apps_dev)
+    namespaces = v1.list_namespace(label_selector="workload-type=application")
+    ns_names = [ns.metadata.name for ns in namespaces.items]
+    logger.info("Tenant namespaces found: %s", ns_names)
+    # At minimum the sre tenant must be present when the cluster is provisioned
+    # with full Flux sync. Skip if not yet deployed.
+    if not ns_names:
+        pytest.skip("No tenant namespaces with workload-type=application found — "
+                    "tenants may not be deployed yet")
+    # All found namespaces must be Active
+    inactive = [
+        ns.metadata.name
+        for ns in namespaces.items
+        if ns.status.phase != "Active"
+    ]
+    assert not inactive, f"Tenant namespaces not Active: {inactive}"
+
+
+@pytest.mark.apps_dev
+@pytest.mark.tenants
+def test_kgateway_ready(ctx_apps_dev):
+    """kgateway HelmRelease must be Ready on apps-dev."""
+    from conftest import wait_for_condition
+    wait_for_condition(
+        ctx_apps_dev,
+        "helm.toolkit.fluxcd.io", "v2", "helmreleases",
+        "kgateway-system", "kgateway",
+        timeout=180,
+    )


### PR DESCRIPTION
This PR introduces long overdue e2e tests!

This pull request introduces a comprehensive end-to-end testing suite for the playground fleet, including a new Claude skill definition, Taskfile integrations, and specialized test modules for Flux, Crossplane, LitmusChaos, and tenant workloads. The suite is designed for determinism, relying on Kubernetes condition polling rather than fixed timing. Feedback from the review suggests strengthening the port_forward helper's error handling, optimizing polling intervals to reduce execution time, and ensuring full adherence to determinism rules by replacing static sleeps and one-shot assertions with robust wait logic.

   1. Robust Polling & Feedback (conftest.py):
       * Default polling interval from 1s for faster execution.
       * Progress logging (every 10 seconds) to all wait_for_* helpers, ensuring the CLI doesn't appear stuck.
       * `wait_for_deletion`, `wait_for_deployment_ready`, `wait_for_nodes_ready`, and `wait_for_flux_ready` to replace fragile one-shot assertions.

   2. Enhanced Port Forwarding (conftest.py):
       * The port_forward helper now monitors the kubectl process. If it crashes (e.g., due to a missing service), it raises a RuntimeError immediately with the process output instead of hanging.
       * It now raises a descriptive TimeoutError if the connection cannot be established within the deadline.

   3. Determinism & Reliability (Test Files):
       * test_litmus.py: Replaced time.sleep(3) with wait_for_deletion for ChaosEngine and ChaosResult, ensuring a clean slate before starting experiments.
       * test_kagent.py & test_tenants.py: Replaced assert_resource_ready (one-shot) with wait_for_condition, allowing time for Flux or Helm controllers to complete reconciliations.
       * test_crossplane.py: Refactored to wait for both Installed and Healthy conditions on providers, and Synced + Ready on composite resources (XRs).
       * test_flux.py & test_fleet.py: Moved to the new polling helpers to ensure they handle eventual consistency in the cluster state.