### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,77 @@
+name: E2E Tests
+
+# Runs GKE e2e tests. Callable from the release workflow or dispatched standalone.
+# GKE infra must already be running; kind cluster is excluded.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Label for artifact naming (defaults to run ID)'
+        required: false
+        type: string
+      skip_chaos:
+        description: 'Skip LitmusChaos experiments (destructive — skip unless explicitly testing chaos resilience)'
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      skip_chaos:
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Tests (GKE only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          project_id: ${{ secrets.PROJECT_ID }}
+
+      - name: Mask project ID
+        run: echo "::add-mask::${{ secrets.PROJECT_ID }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install e2e dependencies
+        run: pip install -r tests/e2e/requirements.txt
+
+      - name: Run e2e tests (GKE clusters, kind excluded)
+        env:
+          CLOUDSDK_CORE_PROJECT: ${{ secrets.PROJECT_ID }}
+        run: |
+          MARKS="not kind"
+          if [ "${{ inputs.skip_chaos }}" = "true" ]; then
+            MARKS="$MARKS and not slow"
+          fi
+          mkdir -p release-artifacts
+          pytest tests/e2e \
+            -v --tb=short \
+            -m "$MARKS" \
+            --junit-xml=release-artifacts/junit.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-${{ inputs.version || github.run_id }}
+          path: release-artifacts/
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Release
+
+run-name: "Release ${{ inputs.version }}"
+
+# Manually triggered. GKE infra must already be running.
+# kind tests are excluded; kind cluster is not expected to be present.
+# Produces an attested JUnit XML attached to the GitHub release as an
+# immutable record of platform state at the time of tagging.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.2.3)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        type: boolean
+        default: false
+      skip_chaos:
+        description: 'Skip LitmusChaos experiments (destructive — skip unless explicitly testing chaos resilience)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write      # create tag + release + upload assets
+  id-token: write      # Workload Identity Federation + attestation signing
+  attestations: write  # actions/attest-build-provenance
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: E2E Tests (GKE only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          project_id: ${{ secrets.PROJECT_ID }}
+
+      - name: Mask project ID
+        run: echo "::add-mask::${{ secrets.PROJECT_ID }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install e2e dependencies
+        run: pip install -r tests/e2e/requirements.txt
+
+      - name: Run e2e tests (GKE clusters, kind excluded)
+        env:
+          # Ensures gcloud subprocess calls from conftest inherit the project.
+          CLOUDSDK_CORE_PROJECT: ${{ secrets.PROJECT_ID }}
+        run: |
+          MARKS="not kind"
+          if [ "${{ inputs.skip_chaos }}" = "true" ]; then
+            MARKS="$MARKS and not slow"
+          fi
+          mkdir -p release-artifacts
+          pytest tests/e2e \
+            -v --tb=short \
+            -m "$MARKS" \
+            --junit-xml=release-artifacts/junit.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-${{ inputs.version }}
+          path: release-artifacts/
+          retention-days: 90
+
+  release:
+    name: Create Release
+    needs: e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-results-${{ inputs.version }}
+          path: release-artifacts/
+
+      # SLSA L2 provenance stored in GitHub's attestation store.
+      # Verify post-release with:
+      #   gh attestation verify release-artifacts/junit.xml --repo <owner>/<repo>
+      - name: Attest test results (SLSA L2)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release-artifacts/junit.xml
+
+      - name: Create and push tag
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
+          git push origin "${{ inputs.version }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "${{ inputs.version }}" \
+            --title "Release ${{ inputs.version }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG \
+            "release-artifacts/junit.xml#E2E test results (JUnit XML)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,53 +34,12 @@ concurrency:
 
 jobs:
   e2e:
-    name: E2E Tests (GKE only)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-          project_id: ${{ secrets.PROJECT_ID }}
-
-      - name: Mask project ID
-        run: echo "::add-mask::${{ secrets.PROJECT_ID }}"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install e2e dependencies
-        run: pip install -r tests/e2e/requirements.txt
-
-      - name: Run e2e tests (GKE clusters, kind excluded)
-        env:
-          # Ensures gcloud subprocess calls from conftest inherit the project.
-          CLOUDSDK_CORE_PROJECT: ${{ secrets.PROJECT_ID }}
-        run: |
-          MARKS="not kind"
-          if [ "${{ inputs.skip_chaos }}" = "true" ]; then
-            MARKS="$MARKS and not slow"
-          fi
-          mkdir -p release-artifacts
-          pytest tests/e2e \
-            -v --tb=short \
-            -m "$MARKS" \
-            --junit-xml=release-artifacts/junit.xml
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-results-${{ inputs.version }}
-          path: release-artifacts/
-          retention-days: 90
+    name: E2E Tests
+    uses: ./.github/workflows/e2e.yml
+    with:
+      version: ${{ inputs.version }}
+      skip_chaos: ${{ inputs.skip_chaos }}
+    secrets: inherit
 
   release:
     name: Create Release

--- a/bootstrap/bootstrap-control-plane-cluster.sh
+++ b/bootstrap/bootstrap-control-plane-cluster.sh
@@ -72,7 +72,7 @@ kubectl --context "${KIND_CLUSTER_CONTEXT}" create secret generic flux-system \
 
 echo "Installing Flux Operator via Helm..."
 # timeout(1) covers the OCI chart download phase; helm's --timeout only covers the k8s --wait phase.
-${TIMEOUT_CMD:+$TIMEOUT_CMD 360} helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
+${TIMEOUT_CMD:+"$TIMEOUT_CMD" 360} helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
     --namespace flux-system \
     --kube-context "${KIND_CLUSTER_CONTEXT}" \
     --wait \

--- a/bootstrap/bootstrap-control-plane-cluster.sh
+++ b/bootstrap/bootstrap-control-plane-cluster.sh
@@ -7,6 +7,9 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 CROSSPLANE_VERSION="v2.2.0"
 KIND_CLUSTER_CONTEXT="kind-${KIND_TEST_CLUSTER_NAME}"
 
+# timeout(1) is GNU coreutils; macOS ships without it (gtimeout via brew install coreutils).
+TIMEOUT_CMD=$(command -v timeout || command -v gtimeout || true)
+
 # echo "Setting up GCP infrastructure (VPC and subnets)..."
 # "${REPO_ROOT}/scripts/setup-gcp-once.sh"
 
@@ -69,7 +72,7 @@ kubectl --context "${KIND_CLUSTER_CONTEXT}" create secret generic flux-system \
 
 echo "Installing Flux Operator via Helm..."
 # timeout(1) covers the OCI chart download phase; helm's --timeout only covers the k8s --wait phase.
-timeout 360 helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
+${TIMEOUT_CMD:+$TIMEOUT_CMD 360} helm upgrade --install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --version 0.48.0 \
     --namespace flux-system \
     --kube-context "${KIND_CLUSTER_CONTEXT}" \
     --wait \

--- a/orchestrator/telemetry.py
+++ b/orchestrator/telemetry.py
@@ -82,10 +82,12 @@ def setup_otel(project_id: str | None = None) -> tuple[bool, str]:
         # (instead of generic_node with empty node_id). This surfaces service.name correctly
         # in Cloud Trace and gives each run its own time series so rapid restarts don't
         # produce "points written too frequently" errors.
+        # Include a startup timestamp so OS PID reuse across days doesn't collide.
+        import time as _time
         resource = Resource.create({
             "service.name": SERVICE_NAME,
             "service.namespace": "playground",
-            "service.instance.id": f"{socket.gethostname()}-{os.getpid()}",
+            "service.instance.id": f"{socket.gethostname()}-{os.getpid()}-{int(_time.time())}",
             "gcp.project_id": project_id,
         })
 


### PR DESCRIPTION
# Release workflow
 
##  Workflow design
  - Manual trigger with version (required), prerelease (bool, default false), skip_chaos (bool, default true)
  - e2e job: WIF auth → gcloud configured → pytest with -m "not kind" (plus not slow when skip_chaos=true) → JUnit XML uploaded as artifact with 90-day retention
  - release job: only runs if e2e passes → attests JUnit XML → creates tag → creates release with JUnit as asset

  GKE credential discovery: conftest's _fetch_credentials calls gcloud container clusters list which auto-discovers both GKE clusters once WIF auth is set up. The CLOUDSDK_CORE_PROJECT env var ensures the
  gcloud subprocess calls from within pytest inherit the project.

 ## SLSA decisions

  | Practice | Verdict | Reason |
  |---|---|---|
  | Immutable test results | Yes | JUnit XML on release = permanent proof infra passed before teardown |
  | actions/attest-build-provenance@v2 (SLSA L2) | Yes | Free, built-in, GitHub-native. Verifiable with `gh attestation verify` |
  | SBOM | No | You publish no packages or images — nothing for consumers to act on |
  | cosign / OCI signing | No | No OCI artifacts in this workflow |
  | slsa-github-generator (L3) | No | Designed for binary releases; adds cross-repo trust dep with no benefit here |

  The attestation stores provenance in GitHub (not in the release) and links it cryptographically to the junit.xml digest — so even if someone replaces the asset, the verification will fail.

# Status

## GitHub Actions Workflows

triggered automatically and passed on first time:

<img width="1422" height="181" alt="Screenshot 2026-05-16 at 5 51 05 pm" src="https://github.com/user-attachments/assets/bb290bc7-fb0c-4d3d-8e85-c6b1b3731f25" />


apps-dev has issues with latest `kagent` version, raised issue.

<img width="1983" height="932" alt="Screenshot 2026-05-16 at 5 55 36 pm" src="https://github.com/user-attachments/assets/110f69b9-42e6-4f9a-8721-d45863ccfaf6" />

## e2e tests locally

```
tests/e2e/test_crossplane.py::test_crossplane_providers_healthy_control_plane
------------------------------------------------------------------------------------------------ live log call ------------------------------------------------------------------------------------------------
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-cloudrun to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-cloudrun reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-cloudrun to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-cloudrun reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-container to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-container reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-container to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-container reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-gke to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-gke reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-gke to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-gke reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-iam to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-iam reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-gcp-iam to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-gcp-iam reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-helm to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-helm reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-helm to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-helm reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-kubernetes to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-kubernetes reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/provider-kubernetes to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/provider-kubernetes reached Healthy=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/upbound-provider-family-gcp to reach Installed=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/upbound-provider-family-gcp reached Installed=True after 0s
INFO     conftest:conftest.py:376 Waiting for providers/upbound-provider-family-gcp to reach Healthy=True (timeout 60s)...
INFO     conftest:conftest.py:386 OK: providers/upbound-provider-family-gcp reached Healthy=True after 0s
PASSED                                                                                                                                                                                                  [  7%]
tests/e2e/test_crossplane.py::test_gkecluster_control_plane_ready
```

