### PR TITLE
Fix e2e tests 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,14 +43,10 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
           project_id: ${{ secrets.PROJECT_ID }}
 
-      - name: Install GKE auth plugin
-        run: |
-          # Use apt to install the plugin as it is the most reliable way on Ubuntu runners
-          sudo apt-get update -y && sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
-          # Configure gcloud to use the plugin
-          gcloud config set sdk/install_base_prefix /usr/lib/google-cloud-sdk
-          export USE_GKE_GCLOUD_AUTH_PLUGIN=True
-          echo "USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> $GITHUB_ENV
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Mask project ID
         run: echo "::add-mask::${{ secrets.PROJECT_ID }}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -497,7 +497,7 @@ def all_flux_resources_ready(ctx: str, cluster_label: str) -> list[str]:
                 continue
             # OCI HelmRepositories are passive references; Flux sets no Ready condition
             # until a HelmRelease pulls from them — "No conditions" is normal here.
-            if plural == "helmrepositories" and item.get("spec", {}).get("type") == "oci":
+            if plural == "helmrepositories" and (item.get("spec") or {}).get("type") == "oci":
                 logger.info("[%s] %s/%s/%s OCI type — skipping condition check", cluster_label, plural, meta.get("namespace", "default"), meta.get("name", "unknown"))
                 continue
             conditions = item.get("status", {}).get("conditions", [])

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -495,6 +495,11 @@ def all_flux_resources_ready(ctx: str, cluster_label: str) -> list[str]:
             if suspended:
                 logger.info("[%s] %s/%s/%s SUSPENDED — skipping", cluster_label, plural, meta["namespace"], meta["name"])
                 continue
+            # OCI HelmRepositories are passive references; Flux sets no Ready condition
+            # until a HelmRelease pulls from them — "No conditions" is normal here.
+            if plural == "helmrepositories" and item.get("spec", {}).get("type") == "oci":
+                logger.info("[%s] %s/%s/%s OCI type — skipping condition check", cluster_label, plural, meta.get("namespace", "default"), meta.get("name", "unknown"))
+                continue
             conditions = item.get("status", {}).get("conditions", [])
             ready = next((c for c in conditions if c.get("type") == "Ready"), None)
             if not ready:


### PR DESCRIPTION
two separate failures - local due to wrong resources name and in GitHub actions. 

# GitHub Actions Problem

## 1. Why  `flux-bootstrap.yml`  succeeded

If you look at the  flux-bootstrap.yml  workflow, the  google-github-actions/auth@v3  step is configured with  token_format: access_token :

```yaml
        - name: Authenticate to Google Cloud
          id: auth
          uses: google-github-actions/auth@v3
          with:
            token_format: access_token
```

Because it generates a raw access token, the subsequent  google-github-actions/get-gke-credentials  step configures  kubectl  to use this static token directly to authenticate to the cluster. This completely bypasses the need for
  `kubectl  to call out to the  gke-gcloud-auth-plugin`.

## 2. Why  e2e.yml  failed

The  `e2e.yml`  workflow failed at the  "Install GKE auth plugin"  step with this error:

```
    E: Unable to locate package google-cloud-sdk-gke-gcloud-auth-plugin
```

  This happened because:

  1. It does not specify  token_format: access_token  in the  auth  step. Without it,  get-gke-credentials  configures  kubectl  to dynamically fetch tokens on-the-fly using the  gke-gcloud-auth-plugin  executable.
  2. To satisfy this requirement, the workflow tries to manually install the plugin using  sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin . However, the standard GitHub Actions  ubuntu-latest  runner doesn't have
  the Google Cloud SDK  apt  repository configured by default, so  apt-get  can't find the package and fails.


## Why Option 2 is better

  ### 1. No Static Tokens in Configuration Files (Most Important)

  With Option 1 ( token_format: access_token ), a raw OAuth access token is generated and injected directly into the plaintext  kubeconfig  file on the runner. While GitHub Actions runners are ephemeral, security best practices
  dictate that we should avoid writing static bearer tokens to disk whenever possible.

  With Option 2, the  kubeconfig  file only contains a reference to the  gke-gcloud-auth-plugin  executable. When  kubectl  runs, it calls the plugin, which dynamically exchanges your Workload Identity Federation (OIDC)
  credentials
  for a short-lived token in memory.

  ### 2. Built-in Token Refresh

  The static access token generated in Option 1 is valid for exactly 1 hour. If your  e2e  tests (or any future additions) happen to take longer than 60 minutes, your pipeline will unexpectedly fail with  Unauthorized  errors. The
  gke-gcloud-auth-plugin  handles token expiration and refreshing automatically behind the scenes.

  ### 3. Alignment with Kubernetes upstream

  Kubernetes officially deprecated and removed "in-tree" cloud provider authentication mechanisms (in v1.26+). The entire ecosystem shifted to using external credential plugins like  gke-gcloud-auth-plugin . Relying on the plugin
  aligns your CI/CD pipeline with the standard way users and systems are expected to authenticate to GKE.

  ### How to apply the Best Practice to  e2e.yml

  To implement this, you should replace the manual  apt-get  step with the official  setup-gcloud  action. Your workflow steps should look like this:

```
          - name: Authenticate to Google Cloud
            uses: google-github-actions/auth@v3
            with:
              workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
              service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
              project_id: ${{ secrets.PROJECT_ID }}
              # (Do NOT add token_format: access_token here)

          - name: Set up Cloud SDK
            uses: google-github-actions/setup-gcloud@v2
            with:
              install_components: 'gke-gcloud-auth-plugin'
```

TODO  (Note: While  flux-bootstrap.yml  currently uses the  access_token  method and it works perfectly fine for its quick execution time, standardizing both workflows to use the auth plugin would be a great long-term improvement for
  your repository).