### PR TITLE
chore: fix remaining e2e and align CI with local test execution

### DIFF
--- a/kubernetes/namespaces/base/kagent/kagent/config/rbac.yaml
+++ b/kubernetes/namespaces/base/kagent/kagent/config/rbac.yaml
@@ -54,7 +54,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kagent-crossplane-github-access-binding
+  name: kagent-crossplane-github-access
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/tenants/base/team-charlie/kagent-agents.yaml
+++ b/kubernetes/tenants/base/team-charlie/kagent-agents.yaml
@@ -48,8 +48,6 @@ spec:
       - tenants/ contains team workloads and applications
       - namespaces/ contains platform services and configurations
 
-      The project uses Crossplane v2. Use configured Memory to browse documentation for this version of Crossplane
-
       Always provide detailed error analysis and clear fix explanations.
     memory:
       modelConfig: claude-model-config

--- a/kubernetes/tenants/base/team-charlie/kagent-agents.yaml
+++ b/kubernetes/tenants/base/team-charlie/kagent-agents.yaml
@@ -21,8 +21,6 @@ kind: Agent
 metadata:
   name: crossplane-composition-fixer
   namespace: team-charlie
-  annotations:
-    kagent.dev/reconcile-at: "2026-06-27T06:00:00Z"
 spec:
   description: "Troubleshoot and fix Crossplane compositions using k8s-agent for resource inspection"
   declarative:

--- a/tasks/e2e.yaml
+++ b/tasks/e2e.yaml
@@ -23,6 +23,7 @@ tasks:
     desc: "Run full e2e suite against all available clusters (skips unavailable clusters)"
     deps: [setup, dirs]
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short --junit-xml={{.RESULTS_DIR}}/junit-all.xml"
 
   cluster:
@@ -31,30 +32,35 @@ tasks:
     vars:
       CLUSTER: '{{default "apps_dev" .CLUSTER}}'
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m {{.CLUSTER}} --junit-xml={{.RESULTS_DIR}}/junit-{{.CLUSTER}}.xml"
 
   flux:
     desc: "Run Flux health checks only (all clusters)"
     deps: [setup, dirs]
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m flux --junit-xml={{.RESULTS_DIR}}/junit-flux.xml"
 
   kagent:
     desc: "Run kagent functional tests"
     deps: [setup, dirs]
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/test_kagent.py -v --tb=short --junit-xml={{.RESULTS_DIR}}/junit-kagent.xml"
 
   litmus:
     desc: "Run LitmusChaos experiment tests (slow — runs a real chaos experiment)"
     deps: [setup, dirs]
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/test_litmus.py -v --tb=short --junit-xml={{.RESULTS_DIR}}/junit-litmus.xml"
 
   fast:
     desc: "Run all tests except slow chaos experiments"
     deps: [setup, dirs]
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}} -v --tb=short -m 'not slow' --junit-xml={{.RESULTS_DIR}}/junit-fast.xml"
 
   file:
@@ -63,4 +69,5 @@ tasks:
     vars:
       FILE: '{{default "test_fleet.py" .FILE}}'
     cmds:
+      - task: :setup:ensure-contexts
       - "{{.VENV}}/bin/pytest {{.E2E_DIR}}/{{.FILE}} -v --tb=long --junit-xml={{.RESULTS_DIR}}/junit-{{.FILE}}.xml"

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -63,6 +63,44 @@ tasks:
       - echo "🔑 Getting credentials for {{.CLUSTER}} cluster..."
       - gcloud container clusters get-credentials {{.CLUSTER}} --zone={{.ZONE}} --project={{.PROJECT_ID}}
 
+  ensure-contexts:
+    desc: "Ensure kubeconfig contexts for GKE clusters are configured and reachable"
+    vars:
+      ZONE: '{{default "australia-southeast1-a" .ZONE}}'
+      PROJECT_ID: '{{.PROJECT_ID}}'
+      GKE_CONTROL_PLANE_CLUSTER: '{{.GKE_CONTROL_PLANE_CLUSTER | default "control-plane"}}'
+      GKE_APPS_DEV_CLUSTER: '{{.GKE_APPS_DEV_CLUSTER | default "apps-dev"}}'
+    cmds:
+      - |
+        PROJECT_ID="{{.PROJECT_ID}}"
+        ZONE="{{.ZONE}}"
+        GKE_CONTROL_PLANE_CLUSTER="{{.GKE_CONTROL_PLANE_CLUSTER}}"
+        GKE_APPS_DEV_CLUSTER="{{.GKE_APPS_DEV_CLUSTER}}"
+
+        if [ -z "$PROJECT_ID" ] || [ -z "$ZONE" ]; then
+          echo "⚠️ PROJECT_ID or ZONE not set. Skipping GKE context check."
+          exit 0
+        fi
+
+        CP_CONTEXT="gke_${PROJECT_ID}_${ZONE}_${GKE_CONTROL_PLANE_CLUSTER}"
+        AD_CONTEXT="gke_${PROJECT_ID}_${ZONE}_${GKE_APPS_DEV_CLUSTER}"
+
+        ensure_gke_context() {
+          local cluster_name="$1"
+          local expected_context="$2"
+
+          echo "Checking context: $expected_context"
+          if ! kubectl config get-contexts "$expected_context" >/dev/null 2>&1 || ! kubectl --context="$expected_context" cluster-info --request-timeout=5s >/dev/null 2>&1; then
+            echo "🔑 Context '$expected_context' not found or unreachable. Fetching credentials via gcloud..."
+            gcloud container clusters get-credentials "$cluster_name" --zone="$ZONE" --project="$PROJECT_ID"
+          else
+            echo "✅ Context '$expected_context' is active and reachable."
+          fi
+        }
+
+        ensure_gke_context "$GKE_CONTROL_PLANE_CLUSTER" "$CP_CONTEXT"
+        ensure_gke_context "$GKE_APPS_DEV_CLUSTER" "$AD_CONTEXT"
+
   cleanup:
     desc: "Cleanup infrastructure (forcefull)"
     cmds:

--- a/tasks/validate-clusters.yaml
+++ b/tasks/validate-clusters.yaml
@@ -86,6 +86,7 @@ tasks:
       ZONE: '{{default "australia-southeast1-a" .ZONE}}'
     silent: true
     cmds:
+      - task: :setup:ensure-contexts
       - echo "🔍 Validating control-plane cluster ({{.CONTEXT}})..."
       - |
         # Check Crossplane is installed and providers are ready
@@ -114,6 +115,7 @@ tasks:
       ZONE: '{{default "australia-southeast1-a" .ZONE}}'
     silent: true
     cmds:
+      - task: :setup:ensure-contexts
       - echo "🔍 Validating workload cluster apps-dev ({{.CONTEXT}})..."
       - |
         # Check if cluster is accessible
@@ -155,6 +157,7 @@ tasks:
     vars:
       ZONE: '{{default "australia-southeast1-a" .ZONE}}'
     cmds:
+      - task: :setup:ensure-contexts
       - echo "🏛️  Validating architectural constraints..."
       - |
         echo "1. Bootstrap cluster manages control-plane provisioning:"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -50,52 +50,7 @@ def _find_context(suffix: str) -> str | None:
     return None
 
 
-def _fetch_credentials(cluster_name: str) -> bool:
-    """Try to fetch credentials for a GKE cluster using gcloud."""
-    if IS_GITHUB_ACTIONS:
-        logger.warning(f"Lazy-fetching credentials for {cluster_name} is disabled in CI. "
-                       f"The context must be provided by the GitHub Action workflow.")
-        return False
 
-    if subprocess.run(["which", "gcloud"], capture_output=True).returncode != 0:
-        return False
-
-    logger.info(f"Context for {cluster_name} not found. Attempting to fetch...")
-    try:
-        cmd = [
-            "gcloud", "container", "clusters", "list",
-            "--filter", f"name~{cluster_name}",
-            "--format", "value(name,zone,project)"
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode == 0 and result.stdout.strip():
-            for line in result.stdout.strip().splitlines():
-                parts = line.split()
-                if len(parts) >= 3:
-                    name, zone, project = parts[0], parts[1], parts[2]
-                    if name == cluster_name or name.endswith(f"-{cluster_name}"):
-                        logger.info(f"Found cluster {name} in {zone}. Fetching credentials...")
-                        subprocess.run([
-                            "gcloud", "container", "clusters", "get-credentials",
-                            name, "--zone", zone, "--project", project
-                        ], check=True)
-                        return True
-    except Exception as e:
-        logger.error(f"Failed to fetch credentials for {cluster_name}: {e}")
-    return False
-
-
-def _ensure_context(name: str) -> str | None:
-    ctx = _find_context(name)
-    if ctx and _context_reachable(ctx):
-        return ctx
-
-    if _fetch_credentials(name):
-        ctx = _find_context(name)
-        if ctx and _context_reachable(ctx):
-            return ctx
-
-    return None
 
 
 def _context_reachable(ctx: str) -> bool:
@@ -245,27 +200,18 @@ def ctx_kind() -> str:
 
 @pytest.fixture(scope="session")
 def ctx_control_plane() -> str:
-    ctx = _ensure_context("control-plane")
-    if not ctx:
+    ctx = _find_context("control-plane")
+    if not ctx or not _context_reachable(ctx):
         pytest.skip("control-plane cluster not available")
     return ctx
 
 
 @pytest.fixture(scope="session")
 def ctx_apps_dev() -> str:
-    ctx = _ensure_context("apps-dev")
-    if not ctx:
+    ctx = _find_context("apps-dev")
+    if not ctx or not _context_reachable(ctx):
         pytest.skip("apps-dev cluster not available")
     return ctx
-
-
-@pytest.fixture(scope="session", autouse=True)
-def ensure_all_clusters():
-    """Ensure kubeconfig contexts for both control-plane and apps-dev are present.
-    This runs once per test session and will attempt to fetch credentials if missing.
-    """
-    _ensure_context("control-plane")
-    _ensure_context("apps-dev")
 
 
 

--- a/tests/e2e/test_kagent_a2a.py
+++ b/tests/e2e/test_kagent_a2a.py
@@ -186,11 +186,16 @@ def test_k8s_agent_allowed_namespaces(ctx_apps_dev):
         "k8s-agent",
     )
 
-    allowed_ns = agent["spec"].get("allowedNamespaces", [])
-    assert "team-charlie" in allowed_ns, \
-        f"team-charlie not in k8s-agent allowedNamespaces: {allowed_ns}"
-    assert "kagent-system" in allowed_ns, \
-        f"kagent-system not in k8s-agent allowedNamespaces: {allowed_ns}"
+    allowed_ns = agent["spec"].get("allowedNamespaces", {})
+    # Gateway API pattern: {from: All} permits every namespace implicitly
+    if isinstance(allowed_ns, dict) and allowed_ns.get("from") == "All":
+        pass  # all namespaces allowed, including team-charlie and kagent-system
+    else:
+        ns_list = allowed_ns if isinstance(allowed_ns, list) else []
+        assert "team-charlie" in ns_list, \
+            f"team-charlie not in k8s-agent allowedNamespaces: {allowed_ns}"
+        assert "kagent-system" in ns_list, \
+            f"kagent-system not in k8s-agent allowedNamespaces: {allowed_ns}"
 
     logger.info("k8s-agent allowedNamespaces correctly configured")
 


### PR DESCRIPTION
This pull request refactors how GKE cluster credentials and contexts are managed during end-to-end testing and validation. Instead of lazy-fetching credentials programmatically within Python's conftest.py, the responsibility is shifted to a new Taskfile task (ensure-contexts) that checks and configures contexts via kubectl and gcloud. 

Additionally, the PR updates the allowedNamespaces assertion in the agent tests to support Gateway API patterns and cleans up some metadata. Feedback is provided regarding the new shell script in tasks/setup.yaml, where adding set -e is recommended to prevent credential-fetching failures from being silently ignored.